### PR TITLE
fix: update URLs after org rename from 4lando to lando-community

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Aaron Feledy"
   },
   "version": "1.0.0-beta.1",
-  "repository": "https://github.com/4lando/vscode-lando",
+  "repository": "https://github.com/lando-community/vscode-lando",
   "icon": "resources/icon256.png",
   "engines": {
     "vscode": "^1.91.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2320,7 +2320,7 @@ function registerPhpManagementCommands(
           
           <h2>JSON Schema Source</h2>
           <p>The extension uses the official Lando JSON schema specification:</p>
-          <code>https://4lando.github.io/lando-spec/landofile-spec.json</code>
+          <code>https://lando-community.github.io/lando-spec/landofile-spec.json</code>
           
           <p><em>This ensures all autocomplete, validation, and documentation are based on the official Lando specification.</em></p>
         </body>

--- a/src/landofileSchemaProvider.ts
+++ b/src/landofileSchemaProvider.ts
@@ -15,7 +15,7 @@ import Ajv from 'ajv';
 /**
  * The URL of the Landofile JSON schema
  */
-const LANDOFILE_SCHEMA_URL = 'https://4lando.github.io/lando-spec/landofile-spec.json';
+const LANDOFILE_SCHEMA_URL = 'https://lando-community.github.io/lando-spec/landofile-spec.json';
 
 /**
  * Interface for the cached schema


### PR DESCRIPTION
The `4lando` GitHub org was renamed to `lando-community`. While GitHub redirects repository URLs automatically, **GitHub Pages URLs do not redirect** — meaning `4lando.github.io` returns 404.

This updates all references from `4lando` to `lando-community` to fix broken URLs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates hardcoded GitHub/GitHub Pages URLs used for metadata and schema fetching, with no functional logic changes beyond where the schema is downloaded from.
> 
> **Overview**
> Updates hardcoded URLs from `4lando` to `lando-community` to avoid broken links after the GitHub org rename.
> 
> Specifically, the extension’s `package.json` `repository` URL is updated, and both the Landofile schema fetch URL (`LANDOFILE_SCHEMA_URL`) and the schema source shown in the `showLandofileInfo` webview now point to `https://lando-community.github.io/lando-spec/landofile-spec.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e2f29015dc864deef38ca72487bf04228d29b53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->