### PR TITLE
feat: Add Info panel with database connection details and service logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,16 @@ Seamlessly integrate [Lando](https://lando.dev) local development environments w
   - **Apps**: Root-level display of all detected Lando apps with status icons
   - **Services**: Expandable list of services (appserver, database, redis, etc.) with running state
   - **URLs**: Clickable URLs that open directly in your browser (shown when app is running)
+  - **Info**: Database connection details (host, port, user, password) with one-click copy
   - **Tooling**: One-click access to tooling commands (drush, composer, npm, artisan, etc.)
-- **Inline Actions**: Hover over items to see action buttons (Start, Stop, SSH, Copy URL)
-- **Context Menus**: Right-click for full action menus on apps, services, and URLs
+- **Connection Info at a Glance**: See database credentials and connection details without touching the CLI
+  - External connection info (host/port for connecting from your host machine)
+  - Internal connection info (for container-to-container connections)
+  - Database credentials (user, password, database name)
+  - Click any info item to copy its value to clipboard
+- **Service Actions**: Right-click on services to SSH in or view logs for that specific service
+- **Inline Actions**: Hover over items to see action buttons (Start, Stop, SSH, Copy URL, Copy Info)
+- **Context Menus**: Right-click for full action menus on apps, services, URLs, and info items
 - **Real-time Updates**: Status automatically refreshes when apps start or stop
 
 #### 🚀 **Lando Command Execution**
@@ -49,6 +56,8 @@ Seamlessly integrate [Lando](https://lando.dev) local development environments w
 - **Smart Visibility**: Menu items adapt based on app state (shows "Start" when stopped, "Stop" when running)
 - **Organized Submenu**: All commands grouped under a clean "Lando" submenu
 - **SSH Terminal**: Open a terminal directly connected to any Lando service
+- **View Service Logs**: Right-click a service in the tree view to view its logs in a terminal
+- **Copy Connection Info**: One-click copy for database credentials and connection details
 - **Rebuild Command**: Rebuild your Lando app with a confirmation dialog
 
 #### 📚 **Documentation Access**
@@ -71,7 +80,7 @@ Seamlessly integrate [Lando](https://lando.dev) local development environments w
 - **Real-time Validation**: Live validation with error highlighting for missing required fields, invalid recipes, and service types
 
 ### 🔜 Planned Features
-- [ ] Integrated log viewer with filtering
+- [ ] Integrated log viewer panel with filtering and search
 
 ### 🚀 Future Roadmap
 - Automatic Xdebug configuration

--- a/package.json
+++ b/package.json
@@ -214,6 +214,20 @@
       {
         "command": "lando.runToolingDirect",
         "title": "Run Tooling Command"
+      },
+      {
+        "command": "lando.copyInfoValue",
+        "title": "Copy Value"
+      },
+      {
+        "command": "lando.treeCopyInfo",
+        "title": "Copy Value",
+        "icon": "$(copy)"
+      },
+      {
+        "command": "lando.treeViewServiceLogs",
+        "title": "View Logs",
+        "icon": "$(output)"
       }
     ],
     "submenus": [
@@ -381,6 +395,21 @@
         {
           "command": "lando.treeCopyUrl",
           "when": "view == landoExplorer && viewItem == url",
+          "group": "1_access@1"
+        },
+        {
+          "command": "lando.treeViewServiceLogs",
+          "when": "view == landoExplorer && viewItem == service",
+          "group": "1_access@2"
+        },
+        {
+          "command": "lando.treeCopyInfo",
+          "when": "view == landoExplorer && viewItem == infoItem",
+          "group": "inline"
+        },
+        {
+          "command": "lando.treeCopyInfo",
+          "when": "view == landoExplorer && viewItem == infoItem",
           "group": "1_access@1"
         }
       ]

--- a/src/landoTreeDataProvider.ts
+++ b/src/landoTreeDataProvider.ts
@@ -23,6 +23,8 @@ export type LandoTreeItemType =
   | 'url'
   | 'toolingGroup'
   | 'tooling'
+  | 'infoGroup'
+  | 'infoItem'
   | 'loading'
   | 'noApps';
 
@@ -46,6 +48,66 @@ interface LandoServiceInfo {
   name: string;
   /** The service type (e.g., 'php', 'mysql') */
   type: string;
+  /** Whether the service is running */
+  running?: boolean;
+}
+
+/**
+ * Represents connection credentials for a database service
+ */
+interface LandoConnectionCreds {
+  /** Database username */
+  user?: string;
+  /** Database password */
+  password?: string;
+  /** Database name */
+  database?: string;
+}
+
+/**
+ * Represents connection endpoint information
+ */
+interface LandoConnectionEndpoint {
+  /** Hostname or IP address */
+  host?: string;
+  /** Port number */
+  port?: string;
+}
+
+/**
+ * Represents a copyable info item displayed in the tree
+ */
+interface LandoInfoItem {
+  /** Display label (e.g., "Host", "User", "Password") */
+  label: string;
+  /** The value to display and copy */
+  value: string;
+  /** The service this info belongs to */
+  service: string;
+  /** Category of info (for grouping) */
+  category: 'connection' | 'credentials' | 'other';
+  /** Icon to display */
+  icon?: string;
+}
+
+/**
+ * Extended service info from lando info command
+ */
+interface LandoServiceDetails {
+  /** The service name */
+  service: string;
+  /** The service type (e.g., 'php', 'mysql:8.0') */
+  type?: string;
+  /** URLs exposed by this service */
+  urls?: string[];
+  /** Database credentials (if applicable) */
+  creds?: LandoConnectionCreds;
+  /** Internal connection info (container-to-container) */
+  internal_connection?: LandoConnectionEndpoint;
+  /** External connection info (host machine access) */
+  external_connection?: LandoConnectionEndpoint;
+  /** Container hostnames */
+  hostnames?: string[];
   /** Whether the service is running */
   running?: boolean;
 }
@@ -94,6 +156,13 @@ export class LandoTreeItem extends vscode.TreeItem {
         break;
       case 'tooling':
         this.setupToolingItem();
+        break;
+      case 'infoGroup':
+        this.iconPath = new vscode.ThemeIcon('database');
+        this.description = 'Connection Info';
+        break;
+      case 'infoItem':
+        this.setupInfoItem();
         break;
       case 'loading':
         this.iconPath = new vscode.ThemeIcon('loading~spin');
@@ -183,6 +252,45 @@ export class LandoTreeItem extends vscode.TreeItem {
   }
 
   /**
+   * Sets up an info tree item (connection details, credentials, etc.)
+   */
+  private setupInfoItem(): void {
+    const info = this.data as LandoInfoItem;
+    if (!info) {
+      return;
+    }
+
+    // Choose icon based on category and label
+    let icon = 'symbol-field';
+    if (info.label.toLowerCase().includes('host')) {
+      icon = 'server';
+    } else if (info.label.toLowerCase().includes('port')) {
+      icon = 'plug';
+    } else if (info.label.toLowerCase().includes('user')) {
+      icon = 'person';
+    } else if (info.label.toLowerCase().includes('password')) {
+      icon = 'key';
+    } else if (info.label.toLowerCase().includes('database')) {
+      icon = 'database';
+    }
+
+    this.iconPath = new vscode.ThemeIcon(icon);
+    this.description = info.value;
+    this.tooltip = new vscode.MarkdownString(
+      `**${info.label}:** \`${info.value}\`\n\n` +
+      `Service: ${info.service}\n\n` +
+      `*Click to copy to clipboard*`
+    );
+    
+    // Click to copy the value
+    this.command = {
+      command: 'lando.copyInfoValue',
+      title: 'Copy Value',
+      arguments: [info.value, info.label]
+    };
+  }
+
+  /**
    * Updates the app status icon
    */
   public updateStatus(status: LandoAppStatus | undefined): void {
@@ -234,9 +342,10 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
   private statusMonitor: LandoStatusMonitor | undefined;
   private outputChannel: vscode.OutputChannel | undefined;
   
-  // Cache for services and URLs (fetched via lando info)
+  // Cache for services, URLs, and connection info (fetched via lando info)
   private servicesCache: Map<string, LandoServiceInfo[]> = new Map();
   private urlsCache: Map<string, LandoServiceUrl[]> = new Map();
+  private infoCache: Map<string, LandoInfoItem[]> = new Map();
   private fetchingInfo: Set<string> = new Set();
 
   constructor() {}
@@ -454,6 +563,40 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
         }
       })
     );
+
+    // Copy info value to clipboard (for connection details)
+    context.subscriptions.push(
+      vscode.commands.registerCommand('lando.copyInfoValue', async (value: string, label: string) => {
+        await vscode.env.clipboard.writeText(value);
+        vscode.window.showInformationMessage(`Copied ${label}: ${value}`);
+      })
+    );
+
+    // Copy info item from tree context menu
+    context.subscriptions.push(
+      vscode.commands.registerCommand('lando.treeCopyInfo', async (item: LandoTreeItem) => {
+        if (item.type === 'infoItem') {
+          const info = item.data as LandoInfoItem;
+          await vscode.env.clipboard.writeText(info.value);
+          vscode.window.showInformationMessage(`Copied ${info.label}: ${info.value}`);
+        }
+      })
+    );
+
+    // View logs for a specific service from tree
+    context.subscriptions.push(
+      vscode.commands.registerCommand('lando.treeViewServiceLogs', async (item: LandoTreeItem) => {
+        if (item.type === 'service' && item.app) {
+          const service = item.data as LandoServiceInfo;
+          const terminal = vscode.window.createTerminal({
+            name: `Lando Logs: ${service.name}`,
+            cwd: item.app.rootPath
+          });
+          terminal.sendText(`lando logs -s ${service.name} -f`);
+          terminal.show();
+        }
+      })
+    );
   }
 
   /**
@@ -499,6 +642,11 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
     // Tooling group: show tooling commands
     if (element.type === 'toolingGroup' && element.app) {
       return this.getToolingItems(element.app);
+    }
+
+    // Info group: show connection details
+    if (element.type === 'infoGroup' && element.app) {
+      return this.getInfoItems(element.app);
     }
 
     return [];
@@ -567,6 +715,15 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
       children.push(new LandoTreeItem(
         'URLs',
         'urlsGroup',
+        vscode.TreeItemCollapsibleState.Collapsed,
+        app
+      ));
+      
+      // Info group - shows database connection details, ports, etc.
+      // Only shown when app is running since we need lando info data
+      children.push(new LandoTreeItem(
+        'Info',
+        'infoGroup',
         vscode.TreeItemCollapsibleState.Collapsed,
         app
       ));
@@ -691,6 +848,37 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
   }
 
   /**
+   * Gets info items (connection details, credentials) for an app.
+   * These are extracted from lando info output for database and other services.
+   */
+  private async getInfoItems(app: LandoApp): Promise<LandoTreeItem[]> {
+    // Check cache first
+    let infoItems = this.infoCache.get(app.configPath);
+    
+    if (!infoItems) {
+      await this.fetchAppInfo(app);
+      infoItems = this.infoCache.get(app.configPath);
+    }
+
+    if (!infoItems || infoItems.length === 0) {
+      return [new LandoTreeItem(
+        'No connection info available',
+        'loading',
+        vscode.TreeItemCollapsibleState.None,
+        app
+      )];
+    }
+
+    return infoItems.map(info => new LandoTreeItem(
+      info.label,
+      'infoItem',
+      vscode.TreeItemCollapsibleState.None,
+      app,
+      info
+    ));
+  }
+
+  /**
    * Fetches app info (services and URLs) from lando info command.
    * Uses async spawn to avoid blocking the VS Code UI thread.
    */
@@ -722,6 +910,7 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
         this.log(`Error spawning lando info for ${app.name}: ${error}`);
         this.servicesCache.set(app.configPath, []);
         this.urlsCache.set(app.configPath, []);
+        this.infoCache.set(app.configPath, []);
         this.fetchingInfo.delete(app.configPath);
         resolve();
       });
@@ -732,20 +921,17 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
             this.log(`lando info failed for ${app.name}: exit code ${code}, stderr: ${stderr}`);
             this.servicesCache.set(app.configPath, []);
             this.urlsCache.set(app.configPath, []);
+            this.infoCache.set(app.configPath, []);
             this.fetchingInfo.delete(app.configPath);
             resolve();
             return;
           }
 
-          const infoArray = JSON.parse(stdout) as Array<{
-            service: string;
-            type?: string;
-            urls?: string[];
-            running?: boolean;
-          }>;
+          const infoArray = JSON.parse(stdout) as LandoServiceDetails[];
 
           const services: LandoServiceInfo[] = [];
           const urls: LandoServiceUrl[] = [];
+          const infoItems: LandoInfoItem[] = [];
 
           for (const info of infoArray) {
             services.push({
@@ -763,12 +949,91 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
                 });
               }
             }
+
+            // Extract connection info for database services
+            // Check if this service has credentials (typical for database services)
+            if (info.creds) {
+              const serviceName = info.service;
+              const serviceLabel = `${serviceName}`;
+              
+              if (info.creds.database) {
+                infoItems.push({
+                  label: `${serviceLabel}: Database`,
+                  value: info.creds.database,
+                  service: serviceName,
+                  category: 'credentials'
+                });
+              }
+              if (info.creds.user) {
+                infoItems.push({
+                  label: `${serviceLabel}: User`,
+                  value: info.creds.user,
+                  service: serviceName,
+                  category: 'credentials'
+                });
+              }
+              if (info.creds.password) {
+                infoItems.push({
+                  label: `${serviceLabel}: Password`,
+                  value: info.creds.password,
+                  service: serviceName,
+                  category: 'credentials'
+                });
+              }
+            }
+
+            // Extract external connection info (for connecting from host machine)
+            if (info.external_connection) {
+              const serviceName = info.service;
+              const serviceLabel = `${serviceName}`;
+              
+              if (info.external_connection.host) {
+                infoItems.push({
+                  label: `${serviceLabel}: Host (external)`,
+                  value: info.external_connection.host,
+                  service: serviceName,
+                  category: 'connection'
+                });
+              }
+              if (info.external_connection.port) {
+                infoItems.push({
+                  label: `${serviceLabel}: Port (external)`,
+                  value: info.external_connection.port,
+                  service: serviceName,
+                  category: 'connection'
+                });
+              }
+            }
+
+            // Extract internal connection info (container-to-container)
+            if (info.internal_connection) {
+              const serviceName = info.service;
+              const serviceLabel = `${serviceName}`;
+              
+              if (info.internal_connection.host) {
+                infoItems.push({
+                  label: `${serviceLabel}: Host (internal)`,
+                  value: info.internal_connection.host,
+                  service: serviceName,
+                  category: 'connection'
+                });
+              }
+              if (info.internal_connection.port) {
+                infoItems.push({
+                  label: `${serviceLabel}: Port (internal)`,
+                  value: info.internal_connection.port,
+                  service: serviceName,
+                  category: 'connection'
+                });
+              }
+            }
           }
 
           this.servicesCache.set(app.configPath, services);
           this.urlsCache.set(app.configPath, urls);
+          this.infoCache.set(app.configPath, infoItems);
           
-          this.log(`Fetched info for ${app.name}: ${services.length} services, ${urls.length} URLs`);
+          this.log(`Fetched info for ${app.name}: ${services.length} services, ${urls.length} URLs, ${infoItems.length} info items`);
         } catch (error) {
           this.log(`Error parsing lando info for ${app.name}: ${error}`);
           this.servicesCache.set(app.configPath, []);
@@ -878,6 +1143,7 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
   private clearCaches(): void {
     this.servicesCache.clear();
     this.urlsCache.clear();
+    this.infoCache.clear();
     this.fetchingInfo.clear();
   }
 

--- a/src/landoTreeDataProvider.ts
+++ b/src/landoTreeDataProvider.ts
@@ -1038,6 +1038,7 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
           this.log(`Error parsing lando info for ${app.name}: ${error}`);
           this.servicesCache.set(app.configPath, []);
           this.urlsCache.set(app.configPath, []);
+          this.infoCache.set(app.configPath, []);
         } finally {
           this.fetchingInfo.delete(app.configPath);
           resolve();
@@ -1051,6 +1052,7 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
           landoProcess.kill();
           this.servicesCache.set(app.configPath, []);
           this.urlsCache.set(app.configPath, []);
+          this.infoCache.set(app.configPath, []);
           this.fetchingInfo.delete(app.configPath);
           resolve();
         }

--- a/src/test/suite/treeView.test.ts
+++ b/src/test/suite/treeView.test.ts
@@ -86,6 +86,30 @@ suite("Lando TreeView Integration Test Suite", () => {
       );
     });
 
+    test("lando.copyInfoValue command should be registered", async () => {
+      const commands = await vscode.commands.getCommands(true);
+      assert.ok(
+        commands.includes("lando.copyInfoValue"),
+        "lando.copyInfoValue command should be registered"
+      );
+    });
+
+    test("lando.treeCopyInfo command should be registered", async () => {
+      const commands = await vscode.commands.getCommands(true);
+      assert.ok(
+        commands.includes("lando.treeCopyInfo"),
+        "lando.treeCopyInfo command should be registered"
+      );
+    });
+
+    test("lando.treeViewServiceLogs command should be registered", async () => {
+      const commands = await vscode.commands.getCommands(true);
+      assert.ok(
+        commands.includes("lando.treeViewServiceLogs"),
+        "lando.treeViewServiceLogs command should be registered"
+      );
+    });
+
     test("All TreeView commands should be registered", async () => {
       const commands = await vscode.commands.getCommands(true);
       const treeViewCommands = [
@@ -97,7 +121,10 @@ suite("Lando TreeView Integration Test Suite", () => {
         "lando.treeCopyUrl",
         "lando.treeOpenSshService",
         "lando.openUrlDirect",
-        "lando.runToolingDirect"
+        "lando.runToolingDirect",
+        "lando.copyInfoValue",
+        "lando.treeCopyInfo",
+        "lando.treeViewServiceLogs"
       ];
 
       treeViewCommands.forEach(cmd => {
@@ -186,6 +213,28 @@ suite("Lando TreeView Integration Test Suite", () => {
       // Check for URL context menu items
       const urlItems = viewItemContextMenu.filter((m) => m.when?.includes("viewItem == url"));
       assert.ok(urlItems.length >= 1, "Should have URL context menu items");
+
+      // Check for info item context menu items
+      const infoItems = viewItemContextMenu.filter((m) => m.when?.includes("viewItem == infoItem"));
+      assert.ok(infoItems.length >= 1, "Should have info item context menu items");
+    });
+
+    test("Should have inline action for info items", () => {
+      const viewItemContextMenu = packageJson.contributes!.menus!["view/item/context"];
+      
+      const copyInfoInline = viewItemContextMenu.find(
+        (m) => m.command === "lando.treeCopyInfo" && m.group === "inline"
+      );
+      assert.ok(copyInfoInline, "Copy Info button should be inline for info items");
+    });
+
+    test("Should have View Logs action for services", () => {
+      const viewItemContextMenu = packageJson.contributes!.menus!["view/item/context"];
+      
+      const viewLogsItem = viewItemContextMenu.find(
+        (m) => m.command === "lando.treeViewServiceLogs" && m.when?.includes("viewItem == service")
+      );
+      assert.ok(viewLogsItem, "View Logs should be available for services");
     });
 
     test("Should have inline action buttons for apps", () => {
@@ -279,6 +328,22 @@ suite("Lando TreeView Integration Test Suite", () => {
       );
       assert.ok(sshCmd, "SSH service command should be defined");
       assert.strictEqual(sshCmd?.icon, "$(terminal)", "SSH should have terminal icon");
+    });
+
+    test("Copy Info command should have icon", () => {
+      const copyInfoCmd = packageJson.contributes!.commands!.find(
+        (c) => c.command === "lando.treeCopyInfo"
+      );
+      assert.ok(copyInfoCmd, "Copy Info command should be defined");
+      assert.strictEqual(copyInfoCmd?.icon, "$(copy)", "Copy Info should have copy icon");
+    });
+
+    test("View Service Logs command should have icon", () => {
+      const viewLogsCmd = packageJson.contributes!.commands!.find(
+        (c) => c.command === "lando.treeViewServiceLogs"
+      );
+      assert.ok(viewLogsCmd, "View Service Logs command should be defined");
+      assert.strictEqual(viewLogsCmd?.icon, "$(output)", "View Logs should have output icon");
     });
   });
 


### PR DESCRIPTION
## Summary

This PR improves the UI/UX for GUI-preferring users by surfacing database connection information directly in the Lando Explorer tree view, eliminating the need to use the CLI.

### Changes

- **Info Panel**: Added a new "Info" expandable group in the tree view (shown when app is running) that displays:
  - Database credentials (user, password, database name)
  - External connection details (host/port for connecting from host machine)
  - Internal connection details (host/port for container-to-container connections)
  
- **One-Click Copy**: Click any info item to instantly copy its value to clipboard

- **View Service Logs**: Added "View Logs" context menu option for individual services in the tree

### Why This Matters

Before this change, users who weren't comfortable with CLI had to:
1. Open a terminal
2. Run `lando info`
3. Parse JSON output to find database credentials
4. Manually copy values

Now they can simply expand the **Info** section in the Lando Explorer and click to copy any value they need.

### Tree View Structure (Updated)

```
📦 my-app (drupal10)                    [Running]
  ├── 📁 Services
  │     ├── ● appserver (php)           [Right-click → View Logs]
  │     └── ● database (mysql)
  ├── 🌐 URLs
  │     └── https://my-app.lndo.site
  ├── 🗄️ Info                           [NEW]
  │     ├── database: Database          → drupal10
  │     ├── database: User              → drupal10
  │     ├── database: Password          → drupal10
  │     ├── database: Host (external)   → localhost
  │     ├── database: Port (external)   → 32769
  │     ├── database: Host (internal)   → database
  │     └── database: Port (internal)   → 3306
  └── 🔧 Tooling
        ├── composer
        └── drush
```

### Screenshots

_Tree view showing new Info section with database credentials_

### Testing

- All existing tests pass (360 passing)
- The 4 failing tests are pre-existing schema validation issues unrelated to this change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes database credentials/connection details in the UI and clipboard and adds new CLI-spawned terminal actions, so behavior and data exposure need review but scope is limited to local dev tooling.
> 
> **Overview**
> **Adds an `Info` group to the Lando Explorer tree (shown when the app is running)** that parses `lando info --format=json` and displays connection details (DB name/user/password plus internal/external host/port) as clickable items that copy values to the clipboard.
> 
> **Extends TreeView actions and contributions** by registering `lando.copyInfoValue`/`lando.treeCopyInfo` (inline + context menu) and `lando.treeViewServiceLogs` (context menu) which opens a terminal running `lando logs -s <service> -f`. Updates caches/error handling to include info items, and expands unit/integration tests plus README feature docs accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 884459d32ad5ef64e06e9caf33b312830d16b0c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->