### PR TITLE
feat: Add one-click database connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Seamlessly integrate [Lando](https://lando.dev) local development environments w
   - External connection info (host/port for connecting from your host machine)
   - Internal connection info (for container-to-container connections)
   - Database credentials (user, password, database name)
+  - **One-Click Connection Strings**: Ready-to-use database URLs (e.g., `mysql://user:pass@localhost:32769/db`) - click to copy and paste directly into DBeaver, TablePlus, or your application config
   - Click any info item to copy its value to clipboard
 - **Service Actions**: Right-click on services to SSH in or view logs for that specific service
 - **Inline Actions**: Hover over items to see action buttons (Start, Stop, SSH, Copy URL, Copy Info)

--- a/package.json
+++ b/package.json
@@ -228,6 +228,15 @@
         "command": "lando.treeViewServiceLogs",
         "title": "View Logs",
         "icon": "$(output)"
+      },
+      {
+        "command": "lando.copyConnectionString",
+        "title": "Copy Connection String"
+      },
+      {
+        "command": "lando.treeCopyConnectionString",
+        "title": "Copy Connection String",
+        "icon": "$(copy)"
       }
     ],
     "submenus": [
@@ -410,6 +419,16 @@
         {
           "command": "lando.treeCopyInfo",
           "when": "view == landoExplorer && viewItem == infoItem",
+          "group": "1_access@1"
+        },
+        {
+          "command": "lando.treeCopyConnectionString",
+          "when": "view == landoExplorer && viewItem == connectionString",
+          "group": "inline"
+        },
+        {
+          "command": "lando.treeCopyConnectionString",
+          "when": "view == landoExplorer && viewItem == connectionString",
           "group": "1_access@1"
         }
       ]

--- a/src/connectionString.test.ts
+++ b/src/connectionString.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Unit tests for the Connection String Generator Module
+ * 
+ * These tests verify that connection strings are generated correctly for
+ * various database types supported by Lando.
+ */
+
+import * as assert from 'assert';
+import { suite, test } from 'mocha';
+import {
+  extractDatabaseType,
+  getProtocolForDatabaseType,
+  isSupportedDatabaseType,
+  encodePassword,
+  buildConnectionUrl,
+  generateConnectionStrings,
+  ConnectionStringInput,
+} from './connectionString';
+
+suite('Connection String Generator', () => {
+  suite('extractDatabaseType', () => {
+    test('should extract base type from versioned service type', () => {
+      assert.strictEqual(extractDatabaseType('mysql:8.0'), 'mysql');
+      assert.strictEqual(extractDatabaseType('postgres:14'), 'postgres');
+      assert.strictEqual(extractDatabaseType('mariadb:10.6'), 'mariadb');
+      assert.strictEqual(extractDatabaseType('mongo:4.4'), 'mongo');
+    });
+
+    test('should return base type when no version is specified', () => {
+      assert.strictEqual(extractDatabaseType('mysql'), 'mysql');
+      assert.strictEqual(extractDatabaseType('postgres'), 'postgres');
+      assert.strictEqual(extractDatabaseType('mariadb'), 'mariadb');
+    });
+
+    test('should handle uppercase types', () => {
+      assert.strictEqual(extractDatabaseType('MySQL:8.0'), 'mysql');
+      assert.strictEqual(extractDatabaseType('POSTGRES'), 'postgres');
+    });
+
+    test('should return undefined for undefined input', () => {
+      assert.strictEqual(extractDatabaseType(undefined), undefined);
+    });
+
+    test('should return undefined for empty string', () => {
+      assert.strictEqual(extractDatabaseType(''), undefined);
+    });
+  });
+
+  suite('getProtocolForDatabaseType', () => {
+    test('should return mysql protocol for MySQL types', () => {
+      assert.strictEqual(getProtocolForDatabaseType('mysql'), 'mysql');
+      assert.strictEqual(getProtocolForDatabaseType('mariadb'), 'mysql');
+    });
+
+    test('should return postgresql protocol for PostgreSQL types', () => {
+      assert.strictEqual(getProtocolForDatabaseType('postgres'), 'postgresql');
+      assert.strictEqual(getProtocolForDatabaseType('postgresql'), 'postgresql');
+    });
+
+    test('should return mongodb protocol for MongoDB types', () => {
+      assert.strictEqual(getProtocolForDatabaseType('mongo'), 'mongodb');
+      assert.strictEqual(getProtocolForDatabaseType('mongodb'), 'mongodb');
+    });
+
+    test('should return undefined for unsupported types', () => {
+      assert.strictEqual(getProtocolForDatabaseType('redis'), undefined);
+      assert.strictEqual(getProtocolForDatabaseType('memcached'), undefined);
+      assert.strictEqual(getProtocolForDatabaseType('php'), undefined);
+    });
+
+    test('should return undefined for undefined input', () => {
+      assert.strictEqual(getProtocolForDatabaseType(undefined), undefined);
+    });
+  });
+
+  suite('isSupportedDatabaseType', () => {
+    test('should return true for supported database types', () => {
+      assert.strictEqual(isSupportedDatabaseType('mysql:8.0'), true);
+      assert.strictEqual(isSupportedDatabaseType('postgres:14'), true);
+      assert.strictEqual(isSupportedDatabaseType('mariadb'), true);
+      assert.strictEqual(isSupportedDatabaseType('mongo:4.4'), true);
+    });
+
+    test('should return false for unsupported types', () => {
+      assert.strictEqual(isSupportedDatabaseType('php:8.2'), false);
+      assert.strictEqual(isSupportedDatabaseType('nginx'), false);
+      assert.strictEqual(isSupportedDatabaseType('redis'), false);
+    });
+
+    test('should return false for undefined input', () => {
+      assert.strictEqual(isSupportedDatabaseType(undefined), false);
+    });
+  });
+
+  suite('encodePassword', () => {
+    test('should encode special characters in passwords', () => {
+      assert.strictEqual(encodePassword('pass@word'), 'pass%40word');
+      assert.strictEqual(encodePassword('pass:word'), 'pass%3Aword');
+      assert.strictEqual(encodePassword('pass/word'), 'pass%2Fword');
+      assert.strictEqual(encodePassword('pass?word'), 'pass%3Fword');
+      assert.strictEqual(encodePassword('pass#word'), 'pass%23word');
+    });
+
+    test('should not encode safe characters', () => {
+      assert.strictEqual(encodePassword('password123'), 'password123');
+      assert.strictEqual(encodePassword('MyP4ssw0rd'), 'MyP4ssw0rd');
+    });
+
+    test('should handle empty password', () => {
+      assert.strictEqual(encodePassword(''), '');
+    });
+  });
+
+  suite('buildConnectionUrl', () => {
+    test('should build a MySQL connection URL', () => {
+      const url = buildConnectionUrl('mysql', 'root', 'password', 'localhost', '3306', 'mydb');
+      assert.strictEqual(url, 'mysql://root:password@localhost:3306/mydb');
+    });
+
+    test('should build a PostgreSQL connection URL', () => {
+      const url = buildConnectionUrl('postgresql', 'postgres', 'secret', '127.0.0.1', '5432', 'testdb');
+      assert.strictEqual(url, 'postgresql://postgres:secret@127.0.0.1:5432/testdb');
+    });
+
+    test('should URL-encode passwords with special characters', () => {
+      const url = buildConnectionUrl('mysql', 'user', 'p@ss:word', 'localhost', '3306', 'db');
+      assert.strictEqual(url, 'mysql://user:p%40ss%3Aword@localhost:3306/db');
+    });
+  });
+
+  suite('generateConnectionStrings', () => {
+    test('should generate connection strings for MySQL service with full info', () => {
+      const input: ConnectionStringInput = {
+        serviceName: 'database',
+        serviceType: 'mysql:8.0',
+        creds: {
+          user: 'lamp',
+          password: 'lamp',
+          database: 'lamp',
+        },
+        externalConnection: {
+          host: '127.0.0.1',
+          port: '32769',
+        },
+        internalConnection: {
+          host: 'database',
+          port: '3306',
+        },
+      };
+
+      const results = generateConnectionStrings(input);
+
+      assert.strictEqual(results.length, 2);
+
+      // Check external connection string
+      const external = results.find(r => r.type === 'external');
+      assert.ok(external);
+      assert.strictEqual(external.connectionString, 'mysql://lamp:lamp@127.0.0.1:32769/lamp');
+      assert.strictEqual(external.protocol, 'mysql');
+      assert.strictEqual(external.serviceName, 'database');
+      assert.ok(external.label.includes('external'));
+
+      // Check internal connection string
+      const internal = results.find(r => r.type === 'internal');
+      assert.ok(internal);
+      assert.strictEqual(internal.connectionString, 'mysql://lamp:lamp@database:3306/lamp');
+      assert.strictEqual(internal.protocol, 'mysql');
+      assert.ok(internal.label.includes('internal'));
+    });
+
+    test('should generate connection strings for PostgreSQL service', () => {
+      const input: ConnectionStringInput = {
+        serviceName: 'postgres',
+        serviceType: 'postgres:14',
+        creds: {
+          user: 'postgres',
+          password: 'postgres',
+          database: 'database',
+        },
+        externalConnection: {
+          host: '127.0.0.1',
+          port: '32770',
+        },
+      };
+
+      const results = generateConnectionStrings(input);
+
+      assert.strictEqual(results.length, 1);
+      const external = results[0];
+      assert.strictEqual(external.connectionString, 'postgresql://postgres:postgres@127.0.0.1:32770/database');
+      assert.strictEqual(external.protocol, 'postgresql');
+      assert.strictEqual(external.type, 'external');
+    });
+
+    test('should generate connection strings for MariaDB service', () => {
+      const input: ConnectionStringInput = {
+        serviceName: 'mariadb',
+        serviceType: 'mariadb:10.6',
+        creds: {
+          user: 'mariadb',
+          password: 'mariadb',
+          database: 'mariadb',
+        },
+        externalConnection: {
+          host: 'localhost',
+          port: '32771',
+        },
+      };
+
+      const results = generateConnectionStrings(input);
+
+      assert.strictEqual(results.length, 1);
+      // MariaDB uses mysql protocol
+      assert.strictEqual(results[0].protocol, 'mysql');
+      assert.ok(results[0].connectionString.startsWith('mysql://'));
+    });
+
+    test('should generate connection strings for MongoDB service', () => {
+      const input: ConnectionStringInput = {
+        serviceName: 'mongo',
+        serviceType: 'mongo:4.4',
+        creds: {
+          user: 'admin',
+          password: 'admin',
+          database: 'admin',
+        },
+        externalConnection: {
+          host: '127.0.0.1',
+          port: '27017',
+        },
+      };
+
+      const results = generateConnectionStrings(input);
+
+      assert.strictEqual(results.length, 1);
+      assert.strictEqual(results[0].protocol, 'mongodb');
+      assert.strictEqual(results[0].connectionString, 'mongodb://admin:admin@127.0.0.1:27017/admin');
+    });
+
+    test('should return empty array for non-database services', () => {
+      const input: ConnectionStringInput = {
+        serviceName: 'appserver',
+        serviceType: 'php:8.2',
+      };
+
+      const results = generateConnectionStrings(input);
+      assert.strictEqual(results.length, 0);
+    });
+
+    test('should return empty array when credentials are missing', () => {
+      const input: ConnectionStringInput = {
+        serviceName: 'database',
+        serviceType: 'mysql:8.0',
+        externalConnection: {
+          host: '127.0.0.1',
+          port: '3306',
+        },
+      };
+
+      const results = generateConnectionStrings(input);
+      assert.strictEqual(results.length, 0);
+    });
+
+    test('should return empty array when connection endpoints are missing', () => {
+      const input: ConnectionStringInput = {
+        serviceName: 'database',
+        serviceType: 'mysql:8.0',
+        creds: {
+          user: 'root',
+          password: 'root',
+          database: 'mydb',
+        },
+      };
+
+      const results = generateConnectionStrings(input);
+      assert.strictEqual(results.length, 0);
+    });
+
+    test('should return empty array when credentials are incomplete', () => {
+      const input: ConnectionStringInput = {
+        serviceName: 'database',
+        serviceType: 'mysql:8.0',
+        creds: {
+          user: 'root',
+          // password and database missing
+        },
+        externalConnection: {
+          host: '127.0.0.1',
+          port: '3306',
+        },
+      };
+
+      const results = generateConnectionStrings(input);
+      assert.strictEqual(results.length, 0);
+    });
+
+    test('should handle passwords with special characters', () => {
+      const input: ConnectionStringInput = {
+        serviceName: 'database',
+        serviceType: 'mysql:8.0',
+        creds: {
+          user: 'root',
+          password: 'p@ss:w0rd/test?query#hash',
+          database: 'mydb',
+        },
+        externalConnection: {
+          host: '127.0.0.1',
+          port: '3306',
+        },
+      };
+
+      const results = generateConnectionStrings(input);
+      assert.strictEqual(results.length, 1);
+      // Password should be URL-encoded
+      assert.ok(results[0].connectionString.includes('p%40ss%3Aw0rd%2Ftest%3Fquery%23hash'));
+    });
+  });
+});

--- a/src/connectionString.ts
+++ b/src/connectionString.ts
@@ -112,24 +112,39 @@ export function isSupportedDatabaseType(serviceType: string | undefined): boolea
 }
 
 /**
+ * URL-encodes special characters in a connection string component.
+ * Used for username, password, and database name to handle special characters
+ * like @, :, /, ?, # that would otherwise break the URL format.
+ * 
+ * @param value - The raw value to encode
+ * @returns URL-encoded value safe for use in connection strings
+ */
+export function encodeConnectionComponent(value: string): string {
+  return encodeURIComponent(value);
+}
+
+/**
  * URL-encodes special characters in a password for use in a connection string.
  * 
  * @param password - The raw password
  * @returns URL-encoded password safe for use in connection strings
+ * @deprecated Use encodeConnectionComponent instead
  */
 export function encodePassword(password: string): string {
-  return encodeURIComponent(password);
+  return encodeConnectionComponent(password);
 }
 
 /**
  * Builds a database connection string URL.
+ * All user-provided values (user, password, database) are URL-encoded to handle
+ * special characters that would otherwise break the URL format.
  * 
  * @param protocol - The database protocol (mysql, postgresql, mongodb)
- * @param user - Username
+ * @param user - Username (will be URL-encoded)
  * @param password - Password (will be URL-encoded)
  * @param host - Hostname or IP
  * @param port - Port number
- * @param database - Database name
+ * @param database - Database name (will be URL-encoded)
  * @returns The complete connection string URL
  */
 export function buildConnectionUrl(
@@ -140,8 +155,10 @@ export function buildConnectionUrl(
   port: string,
   database: string
 ): string {
-  const encodedPassword = encodePassword(password);
-  return `${protocol}://${user}:${encodedPassword}@${host}:${port}/${database}`;
+  const encodedUser = encodeConnectionComponent(user);
+  const encodedPassword = encodeConnectionComponent(password);
+  const encodedDatabase = encodeConnectionComponent(database);
+  return `${protocol}://${encodedUser}:${encodedPassword}@${host}:${port}/${encodedDatabase}`;
 }
 
 /**

--- a/src/connectionString.ts
+++ b/src/connectionString.ts
@@ -1,0 +1,213 @@
+/**
+ * Connection String Generator Module
+ * 
+ * Generates ready-to-use database connection URLs from Lando service info.
+ * Supports MySQL, MariaDB, PostgreSQL, and MongoDB.
+ * 
+ * @module connectionString
+ */
+
+/**
+ * Database credentials from Lando service info
+ */
+export interface DatabaseCredentials {
+  user?: string;
+  password?: string;
+  database?: string;
+}
+
+/**
+ * Connection endpoint information
+ */
+export interface ConnectionEndpoint {
+  host?: string;
+  port?: string;
+}
+
+/**
+ * Input for connection string generation
+ */
+export interface ConnectionStringInput {
+  /** The service name (e.g., 'database', 'db') */
+  serviceName: string;
+  /** The service type (e.g., 'mysql:8.0', 'postgres:14', 'mariadb', 'mongo:4.4') */
+  serviceType?: string;
+  /** Database credentials */
+  creds?: DatabaseCredentials;
+  /** External connection endpoint (for host machine connections) */
+  externalConnection?: ConnectionEndpoint;
+  /** Internal connection endpoint (for container-to-container) */
+  internalConnection?: ConnectionEndpoint;
+}
+
+/**
+ * Result of connection string generation
+ */
+export interface ConnectionStringResult {
+  /** Display label for the connection string */
+  label: string;
+  /** The full connection string/URL */
+  connectionString: string;
+  /** Whether this is for external (host) or internal (container) connection */
+  type: 'external' | 'internal';
+  /** The database protocol (mysql, postgresql, mongodb) */
+  protocol: string;
+  /** The service this connection belongs to */
+  serviceName: string;
+}
+
+/**
+ * Maps Lando service types to connection string protocols
+ */
+const SERVICE_TYPE_PROTOCOLS: Record<string, string> = {
+  'mysql': 'mysql',
+  'mariadb': 'mysql',
+  'postgres': 'postgresql',
+  'postgresql': 'postgresql',
+  'mongo': 'mongodb',
+  'mongodb': 'mongodb',
+};
+
+/**
+ * Extracts the base database type from a Lando service type string.
+ * Handles versioned types like 'mysql:8.0', 'postgres:14', etc.
+ * 
+ * @param serviceType - The full service type string from Lando
+ * @returns The base database type (e.g., 'mysql', 'postgres')
+ */
+export function extractDatabaseType(serviceType: string | undefined): string | undefined {
+  if (!serviceType) {
+    return undefined;
+  }
+  
+  // Remove version suffix (e.g., 'mysql:8.0' -> 'mysql')
+  const baseType = serviceType.split(':')[0].toLowerCase();
+  
+  return baseType;
+}
+
+/**
+ * Gets the connection string protocol for a database type
+ * 
+ * @param databaseType - The base database type (e.g., 'mysql', 'postgres')
+ * @returns The protocol string (e.g., 'mysql', 'postgresql') or undefined if unsupported
+ */
+export function getProtocolForDatabaseType(databaseType: string | undefined): string | undefined {
+  if (!databaseType) {
+    return undefined;
+  }
+  
+  return SERVICE_TYPE_PROTOCOLS[databaseType];
+}
+
+/**
+ * Checks if a service type is a supported database type
+ * 
+ * @param serviceType - The service type string from Lando
+ * @returns true if this is a database type we can generate connection strings for
+ */
+export function isSupportedDatabaseType(serviceType: string | undefined): boolean {
+  const baseType = extractDatabaseType(serviceType);
+  return baseType !== undefined && SERVICE_TYPE_PROTOCOLS[baseType] !== undefined;
+}
+
+/**
+ * URL-encodes special characters in a password for use in a connection string.
+ * 
+ * @param password - The raw password
+ * @returns URL-encoded password safe for use in connection strings
+ */
+export function encodePassword(password: string): string {
+  return encodeURIComponent(password);
+}
+
+/**
+ * Builds a database connection string URL.
+ * 
+ * @param protocol - The database protocol (mysql, postgresql, mongodb)
+ * @param user - Username
+ * @param password - Password (will be URL-encoded)
+ * @param host - Hostname or IP
+ * @param port - Port number
+ * @param database - Database name
+ * @returns The complete connection string URL
+ */
+export function buildConnectionUrl(
+  protocol: string,
+  user: string,
+  password: string,
+  host: string,
+  port: string,
+  database: string
+): string {
+  const encodedPassword = encodePassword(password);
+  return `${protocol}://${user}:${encodedPassword}@${host}:${port}/${database}`;
+}
+
+/**
+ * Generates connection strings for a database service.
+ * Returns both external (host machine) and internal (container) connection strings
+ * when the relevant endpoint information is available.
+ * 
+ * @param input - The service information from Lando
+ * @returns Array of connection string results (may be empty if not a database or missing info)
+ */
+export function generateConnectionStrings(input: ConnectionStringInput): ConnectionStringResult[] {
+  const results: ConnectionStringResult[] = [];
+  
+  // Check if this is a supported database type
+  const baseType = extractDatabaseType(input.serviceType);
+  const protocol = getProtocolForDatabaseType(baseType);
+  
+  if (!protocol) {
+    return results;
+  }
+  
+  // Check if we have the required credentials
+  const { creds } = input;
+  if (!creds?.user || !creds?.password || !creds?.database) {
+    return results;
+  }
+  
+  // Generate external connection string (for connecting from host machine)
+  if (input.externalConnection?.host && input.externalConnection?.port) {
+    const connectionString = buildConnectionUrl(
+      protocol,
+      creds.user,
+      creds.password,
+      input.externalConnection.host,
+      input.externalConnection.port,
+      creds.database
+    );
+    
+    results.push({
+      label: `${input.serviceName}: Connection URL (external)`,
+      connectionString,
+      type: 'external',
+      protocol,
+      serviceName: input.serviceName,
+    });
+  }
+  
+  // Generate internal connection string (for container-to-container connections)
+  if (input.internalConnection?.host && input.internalConnection?.port) {
+    const connectionString = buildConnectionUrl(
+      protocol,
+      creds.user,
+      creds.password,
+      input.internalConnection.host,
+      input.internalConnection.port,
+      creds.database
+    );
+    
+    results.push({
+      label: `${input.serviceName}: Connection URL (internal)`,
+      connectionString,
+      type: 'internal',
+      protocol,
+      serviceName: input.serviceName,
+    });
+  }
+  
+  return results;
+}


### PR DESCRIPTION
## Summary

- Adds ready-to-use connection URLs for database services that users can copy with a single click
- Improves UX for users connecting to databases from GUI tools like DBeaver, TablePlus, or phpMyAdmin

## Problem

Previously, users who wanted to connect to a Lando database from external tools had to manually copy 4-5 separate values:
- Host
- Port  
- Username
- Password
- Database name

This was tedious and error-prone, especially for users not comfortable with the CLI.

## Solution

The extension now generates complete connection strings that can be copied with one click:

| Database | Connection String |
|----------|-------------------|
| MySQL | `mysql://user:password@localhost:32769/database` |
| MariaDB | `mysql://user:password@localhost:32769/database` |
| PostgreSQL | `postgresql://user:password@localhost:32770/database` |
| MongoDB | `mongodb://admin:password@localhost:27017/admin` |

### Features

- **Two connection types per service:**
  - **External** - for connecting from your host machine (IDE, database tools)
  - **Internal** - for container-to-container connections (application config)
- **Password encoding** - Special characters (`@`, `:`, `/`, `?`, `#`) are properly URL-encoded
- **Visual distinction** - Connection strings have a blue link icon to stand out from other info items
- **Helpful tooltips** - Explains when to use external vs internal connection strings

## Files Changed

- `src/connectionString.ts` - New pure logic module for generating connection strings
- `src/connectionString.test.ts` - 28 unit tests covering all database types and edge cases
- `src/landoTreeDataProvider.ts` - Integration with tree view
- `package.json` - New commands and context menu entries
- `README.md` - Documentation update

## Testing

All 28 new unit tests pass. The 4 failing tests in CI are pre-existing schema validation issues unrelated to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes combined credential-bearing DB URLs in the tree/tooltip and clipboard, so mistakes could leak secrets or confuse users if parsing is wrong. Logic is well-covered by unit tests, but it touches connection/credential UX paths.
> 
> **Overview**
> Adds **one-click, ready-to-use database connection URLs** (external and internal) to the Lando Explorer `Info` section, displayed as distinct `connectionString` tree items with a link icon, truncated description, and copy-on-click behavior.
> 
> Introduces a new `connectionString` utility (with unit tests) to generate properly URL-encoded connection strings for supported DB services, wires it into `landoTreeDataProvider`’s `lando info` parsing, and registers new `Copy Connection String` commands/context-menu entries; documentation is updated to mention the feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5565a874ab90f06e766fc96e1c58ef8d15365371. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->