### PR TITLE
feat: Add Destroy App and Power Off All commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Seamlessly integrate [Lando](https://lando.dev) local development environments w
 - **Copy Connection Info**: One-click copy for database credentials and connection details
 - **Rebuild Command**: Rebuild your Lando app with a confirmation dialog
 - **Destroy Command**: Completely remove app containers with safety confirmations
-- **Power Off All**: Stop all running Lando containers system-wide with one click
+- **Power Off**: Stop all running Lando containers system-wide with one click
 
 #### 📚 **Documentation Access**
 - **Quick Access**: Open Lando documentation directly from VS Code (`Ctrl+Shift+P` → "Lando: Open Documentation")
@@ -123,7 +123,7 @@ Access these commands via the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
 - **"Lando: Restart App"** - Restart the active Lando app
 - **"Lando: Rebuild App"** - Rebuild the active Lando app (destroys and recreates containers)
 - **"Lando: Destroy App"** - Completely destroy the active Lando app (removes containers, networks, volumes)
-- **"Lando: Power Off All"** - Stop all running Lando containers on your system
+- **"Lando: Power Off"** - Stop all running Lando containers on your system
 - **"Lando: Open App URL"** - Open the app URL in your default browser
 - **"Lando: Copy App URL"** - Copy the app URL to clipboard
 - **"Lando: Open Terminal (SSH)"** - Open a terminal connected to a Lando service

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Seamlessly integrate [Lando](https://lando.dev) local development environments w
 - **View Service Logs**: Right-click a service in the tree view to view its logs in a terminal
 - **Copy Connection Info**: One-click copy for database credentials and connection details
 - **Rebuild Command**: Rebuild your Lando app with a confirmation dialog
+- **Destroy Command**: Completely remove app containers with safety confirmations
+- **Power Off All**: Stop all running Lando containers system-wide with one click
 
 #### 📚 **Documentation Access**
 - **Quick Access**: Open Lando documentation directly from VS Code (`Ctrl+Shift+P` → "Lando: Open Documentation")
@@ -120,6 +122,8 @@ Access these commands via the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
 - **"Lando: Stop App"** - Stop the active Lando app
 - **"Lando: Restart App"** - Restart the active Lando app
 - **"Lando: Rebuild App"** - Rebuild the active Lando app (destroys and recreates containers)
+- **"Lando: Destroy App"** - Completely destroy the active Lando app (removes containers, networks, volumes)
+- **"Lando: Power Off All"** - Stop all running Lando containers on your system
 - **"Lando: Open App URL"** - Open the app URL in your default browser
 - **"Lando: Copy App URL"** - Copy the app URL to clipboard
 - **"Lando: Open Terminal (SSH)"** - Open a terminal connected to a Lando service

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
       },
       {
         "command": "extension.powerOffLando",
-        "title": "Lando: Power Off All",
+        "title": "Lando: Power Off",
         "icon": "$(debug-disconnect)"
       },
       {

--- a/package.json
+++ b/package.json
@@ -168,6 +168,16 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "extension.destroyLandoApp",
+        "title": "Lando: Destroy App",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "extension.powerOffLando",
+        "title": "Lando: Power Off All",
+        "icon": "$(debug-disconnect)"
+      },
+      {
         "command": "extension.openLandoTerminal",
         "title": "Lando: Open Terminal (SSH)",
         "icon": "$(terminal)"
@@ -268,6 +278,15 @@
           "when": "lando:hasActiveApp"
         },
         {
+          "command": "extension.destroyLandoApp",
+          "group": "1_lifecycle@5",
+          "when": "lando:hasActiveApp"
+        },
+        {
+          "command": "extension.powerOffLando",
+          "group": "1_lifecycle@6"
+        },
+        {
           "command": "extension.openLandoUrl",
           "group": "2_access@1",
           "when": "lando:hasActiveApp && lando:appRunning"
@@ -328,6 +347,11 @@
           "command": "lando.refreshExplorer",
           "when": "view == landoExplorer",
           "group": "navigation"
+        },
+        {
+          "command": "extension.powerOffLando",
+          "when": "view == landoExplorer",
+          "group": "2_actions"
         }
       ],
       "view/item/context": [
@@ -365,6 +389,11 @@
           "command": "extension.rebuildLandoApp",
           "when": "view == landoExplorer && viewItem == app",
           "group": "1_lifecycle@4"
+        },
+        {
+          "command": "extension.destroyLandoApp",
+          "when": "view == landoExplorer && viewItem == app",
+          "group": "1_lifecycle@5"
         },
         {
           "command": "lando.treeOpenTerminal",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1492,7 +1492,7 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
     })
   );
 
-  // Command to power off all Lando containers globally
+  // Command to power off Lando containers globally
   context.subscriptions.push(
     vscode.commands.registerCommand('extension.powerOffLando', async () => {
       // Confirm the action
@@ -1500,11 +1500,11 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
         `Power off all Lando containers?\n\n` +
         `This will stop ALL running Lando apps on your system, not just the ones in this workspace.`,
         { modal: true },
-        'Power Off All',
+        'Power Off',
         'Cancel'
       );
 
-      if (confirm !== 'Power Off All') {
+      if (confirm !== 'Power Off') {
         return;
       }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1685,13 +1685,19 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
       }
 
       // Second confirmation for extra safety
-      const doubleConfirm = await vscode.window.showWarningMessage(
-        `Are you absolutely sure? Type the app name to confirm.`,
-        { modal: true },
-        'Yes, Destroy It'
-      );
+      const appName = activeLandoApp.name;
+      const typedName = await vscode.window.showInputBox({
+        prompt: `Type the app name "${appName}" to confirm destruction`,
+        placeHolder: appName,
+        validateInput: (value) => {
+          if (value !== appName) {
+            return 'App name does not match';
+          }
+          return null;
+        }
+      });
 
-      if (doubleConfirm !== 'Yes, Destroy It') {
+      if (typedName !== appName) {
         return;
       }
 

--- a/src/test/suite/contextMenu.test.ts
+++ b/src/test/suite/contextMenu.test.ts
@@ -209,24 +209,50 @@ suite("Context Menu Integration Test Suite", () => {
   });
 
   suite("Context Menu Command Behavior - New Commands", () => {
-    test("destroyLandoApp handles no active app gracefully", async () => {
-      // When no active app is selected, the command should complete without throwing.
+    test("destroyLandoApp shows error when no active app", async () => {
+      const originalShowErrorMessage = vscode.window.showErrorMessage;
+      let errorShown = false;
+      let errorMessage = "";
+
+      (vscode.window as any).showErrorMessage = (message: string) => {
+        errorShown = true;
+        errorMessage = message;
+        return Promise.resolve(undefined);
+      };
+
       try {
         await vscode.commands.executeCommand("extension.destroyLandoApp");
-        assert.ok(true, "Command should complete without throwing");
-      } catch (_error) {
-        assert.ok(true, "Command may throw when no active app - both behaviors are acceptable");
+        assert.ok(errorShown, "Expected error message to be shown when no active app");
+        assert.ok(
+          errorMessage.includes("No active Lando app"),
+          `Expected 'No active Lando app' in error message, got: ${errorMessage}`
+        );
+      } finally {
+        (vscode.window as any).showErrorMessage = originalShowErrorMessage;
       }
     });
 
-    test("powerOffLando handles execution gracefully", async () => {
-      // Power Off doesn't require an active app but needs user confirmation.
-      // In test mode it should either show confirmation dialog or complete without error.
+    test("powerOffLando shows confirmation dialog", async () => {
+      const originalShowWarningMessage = vscode.window.showWarningMessage;
+      let warningShown = false;
+      let warningMessage = "";
+
+      (vscode.window as any).showWarningMessage = (message: string) => {
+        warningShown = true;
+        warningMessage = message;
+        // Return undefined to simulate user dismissing the dialog
+        return Promise.resolve(undefined);
+      };
+
       try {
         await vscode.commands.executeCommand("extension.powerOffLando");
-        assert.ok(true, "Command should complete without throwing");
-      } catch (_error) {
-        assert.ok(true, "Command may throw - both behaviors are acceptable");
+        assert.ok(warningShown, "Expected confirmation dialog to be shown");
+        assert.ok(
+          warningMessage.includes("Power off all Lando containers"),
+          `Expected 'Power off all Lando containers' in warning message, got: ${warningMessage}`
+        );
+      } finally {
+        (vscode.window as any).showWarningMessage = originalShowWarningMessage;
       }
     });
   });

--- a/src/test/suite/contextMenu.test.ts
+++ b/src/test/suite/contextMenu.test.ts
@@ -158,7 +158,7 @@ suite("Context Menu Integration Test Suite", () => {
       // Check power off command
       const powerOffCmd = commands.find((c) => c.command === "extension.powerOffLando");
       assert.ok(powerOffCmd, "powerOffLando command should be defined");
-      assert.strictEqual(powerOffCmd?.title, "Lando: Power Off All", "Power Off command should have correct title");
+      assert.strictEqual(powerOffCmd?.title, "Lando: Power Off", "Power Off command should have correct title");
       assert.ok(powerOffCmd?.icon, "Power Off command should have an icon");
     });
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -434,6 +434,35 @@ suite("Extension Test Suite", () => {
         (vscode.window as any).showErrorMessage = originalShowErrorMessage;
       }
     });
+
+    test("Destroy command should show error when no active app", async () => {
+      const originalShowErrorMessage = vscode.window.showErrorMessage;
+      let errorShown = false;
+      let errorMessage = "";
+
+      (vscode.window as any).showErrorMessage = (message: string) => {
+        errorShown = true;
+        errorMessage = message;
+        return Promise.resolve(undefined);
+      };
+
+      try {
+        await vscode.commands.executeCommand("extension.destroyLandoApp");
+        // Verify error was shown when no active app is selected
+        assert.ok(errorShown, "Expected error message to be shown when no active app");
+        assert.ok(errorMessage.includes("No active Lando app"), `Expected 'No active Lando app' in error message, got: ${errorMessage}`);
+      } finally {
+        (vscode.window as any).showErrorMessage = originalShowErrorMessage;
+      }
+    });
+
+    test("Destroy and Power Off commands should be registered", async () => {
+      const commands = await vscode.commands.getCommands();
+      
+      // New commands should be registered
+      assert.ok(commands.includes("extension.destroyLandoApp"), "destroyLandoApp command should be registered");
+      assert.ok(commands.includes("extension.powerOffLando"), "powerOffLando command should be registered");
+    });
   });
 
 });


### PR DESCRIPTION
## Summary

Completes the GUI lifecycle management by adding two important commands that CLI users commonly use but were missing from the extension:

- **Destroy App**: Completely removes containers, networks, and volumes with a two-step confirmation dialog for safety
- **Power Off All**: Stops all running Lando containers system-wide, useful for resource management

## Changes

- Added `destroyLando()` and `powerOffLando()` helper functions in `extension.ts`
- Registered new commands with proper confirmation dialogs
- Added commands to package.json with icons and menu contributions
- Commands available from Command Palette, context menus, and tree view
- Added tests for new commands (5 new test cases)
- Updated README with documentation

## Why This Matters

Before this change, users had to use the CLI for `lando destroy` and `lando poweroff`. Now the full lifecycle is available via GUI:

**Start → Stop → Restart → Rebuild → Destroy** + **Power Off All**

This makes the extension a true GUI alternative to the CLI for users who prefer graphical interfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new destructive lifecycle actions (`lando destroy` and global `lando poweroff`) and refactors existing lifecycle command execution into a shared helper, which could affect start/stop/restart/rebuild behavior if argument/cwd handling changes.
> 
> **Overview**
> Adds two new lifecycle commands to the VS Code Lando extension: **`Lando: Destroy App`** (with strong modal + typed-name confirmation) and **`Lando: Power Off`** (stops all Lando containers system-wide with confirmation), exposed via the command palette, explorer/editor context menus, and the Lando tree view title/actions.
> 
> Refactors lifecycle execution by introducing `runLandoCommand()` and routing `start`, `stop`, `restart`, and `rebuild` through it; updates README and extends integration tests to cover new command registration/menu placement and basic no-active-app behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41ab50991e9cb95cb07dd0801fa6ebebd7deeb5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->