### PR TITLE
feat: Implement state machine for Lando app lifecycle management

### DIFF
--- a/package.json
+++ b/package.json
@@ -280,12 +280,12 @@
         {
           "command": "extension.rebuildLandoApp",
           "group": "1_lifecycle@4",
-          "when": "lando:hasActiveApp && lando:appRunning && !lando:appBusy"
+          "when": "lando:hasActiveApp && !lando:appBusy"
         },
         {
           "command": "extension.destroyLandoApp",
           "group": "1_lifecycle@5",
-          "when": "lando:hasActiveApp && lando:appRunning && !lando:appBusy"
+          "when": "lando:hasActiveApp && !lando:appBusy"
         },
         {
           "command": "extension.powerOffLando",

--- a/package.json
+++ b/package.json
@@ -265,27 +265,27 @@
         {
           "command": "extension.startLandoApp",
           "group": "1_lifecycle@1",
-          "when": "lando:hasActiveApp && !lando:appRunning"
+          "when": "lando:hasActiveApp && !lando:appRunning && !lando:appBusy"
         },
         {
           "command": "extension.stopLandoApp",
           "group": "1_lifecycle@2",
-          "when": "lando:hasActiveApp && lando:appRunning"
+          "when": "lando:hasActiveApp && lando:appRunning && !lando:appBusy"
         },
         {
           "command": "extension.restartLandoApp",
           "group": "1_lifecycle@3",
-          "when": "lando:hasActiveApp && lando:appRunning"
+          "when": "lando:hasActiveApp && lando:appRunning && !lando:appBusy"
         },
         {
           "command": "extension.rebuildLandoApp",
           "group": "1_lifecycle@4",
-          "when": "lando:hasActiveApp"
+          "when": "lando:hasActiveApp && lando:appRunning && !lando:appBusy"
         },
         {
           "command": "extension.destroyLandoApp",
           "group": "1_lifecycle@5",
-          "when": "lando:hasActiveApp"
+          "when": "lando:hasActiveApp && lando:appRunning && !lando:appBusy"
         },
         {
           "command": "extension.powerOffLando",
@@ -294,27 +294,27 @@
         {
           "command": "extension.openLandoUrl",
           "group": "2_access@1",
-          "when": "lando:hasActiveApp && lando:appRunning"
+          "when": "lando:hasActiveApp && lando:appRunning && !lando:appBusy"
         },
         {
           "command": "extension.copyLandoUrl",
           "group": "2_access@2",
-          "when": "lando:hasActiveApp && lando:appRunning"
+          "when": "lando:hasActiveApp && lando:appRunning && !lando:appBusy"
         },
         {
           "command": "extension.openLandoTerminal",
           "group": "2_access@3",
-          "when": "lando:hasActiveApp && lando:appRunning"
+          "when": "lando:hasActiveApp && lando:appRunning && !lando:appBusy"
         },
         {
           "command": "extension.viewLandoLogs",
           "group": "3_tools@1",
-          "when": "lando:hasActiveApp && lando:appRunning"
+          "when": "lando:hasActiveApp && lando:appRunning && !lando:appBusy"
         },
         {
           "command": "extension.runLandoTooling",
           "group": "3_tools@2",
-          "when": "lando:hasActiveApp && lando:appRunning"
+          "when": "lando:hasActiveApp && lando:appRunning && !lando:appBusy"
         },
         {
           "command": "extension.refreshLandoStatus",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,13 @@ import { activateShellDecorations } from "./shellDecorations";
 import { activateLandofileLanguageFeatures } from "./landofileLanguageFeatures";
 import { registerYamlReferenceProvider } from "./yamlReferenceProvider";
 import { LandoAppDetector, LandoApp, LandoTooling } from "./landoAppDetector";
-import { LandoStatusMonitor } from "./landoStatusMonitor";
+import { 
+  LandoStatusMonitor, 
+  LandoAppState,
+  isStateRunning,
+  isStateBusy,
+  getStateLabel,
+} from "./landoStatusMonitor";
 import { LandoTreeDataProvider } from "./landoTreeDataProvider";
 import { 
   LANDO_DOCUMENTATION, 
@@ -1006,21 +1012,33 @@ function updateLandoAppsStatusBar(): void {
   if (activeLandoApp) {
     // Get status from the status monitor
     const status = landoStatusMonitor?.getStatus(activeLandoApp);
-    const isRunning = status?.running ?? false;
+    const appState = status?.state ?? LandoAppState.Unknown;
+    const isRunning = isStateRunning(appState);
+    const isBusy = isStateBusy(appState);
     
-    // Set running context for 'when' clauses in menus
+    // Set context for 'when' clauses in menus
     vscode.commands.executeCommand('setContext', 'lando:appRunning', isRunning);
+    vscode.commands.executeCommand('setContext', 'lando:appBusy', isBusy);
+    vscode.commands.executeCommand('setContext', 'lando:appState', appState);
     
-    // Use different icons for running vs stopped
-    const icon = isRunning ? '$(debug-start)' : '$(debug-stop)';
-    const statusText = isRunning ? 'Running' : 'Stopped';
+    // Use different icons for different states
+    let icon = '$(debug-stop)';
+    if (isRunning) {
+      icon = '$(debug-start)';
+    } else if (isBusy) {
+      icon = '$(sync~spin)';
+    }
+    
+    const statusText = getStateLabel(appState);
     
     landoAppsStatusBarItem.text = `${icon} ${activeLandoApp.name}`;
     
     // Set color based on status
     landoAppsStatusBarItem.backgroundColor = isRunning 
       ? undefined 
-      : new vscode.ThemeColor('statusBarItem.warningBackground');
+      : isBusy
+        ? new vscode.ThemeColor('statusBarItem.prominentBackground')
+        : new vscode.ThemeColor('statusBarItem.warningBackground');
     
     // Build tooltip with status information
     let tooltip = `Lando App: ${activeLandoApp.name}\n`;
@@ -1080,10 +1098,12 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
       
       if (activeLandoApp) {
         const status = landoStatusMonitor?.getStatus(activeLandoApp);
-        const isRunning = status?.running ?? false;
+        const appState = status?.state ?? LandoAppState.Unknown;
+        const isRunning = isStateRunning(appState);
+        const isBusy = isStateBusy(appState);
         
         // Show contextual actions based on status
-        if (isRunning) {
+        if (isRunning && !isBusy) {
           items.push({
             label: '$(link-external) Open in Browser',
             description: `Open ${activeLandoApp.name} URL`,
@@ -1262,7 +1282,7 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
 
       if (activeLandoApp) {
         const status = landoStatusMonitor.getStatus(activeLandoApp);
-        const statusText = status?.running ? 'running' : 'stopped';
+        const statusText = getStateLabel(status?.state ?? LandoAppState.Unknown);
         vscode.window.showInformationMessage(
           `${activeLandoApp.name} is ${statusText}`
         );
@@ -1277,6 +1297,18 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
         vscode.window.showErrorMessage('No active Lando app selected');
         return;
       }
+
+      // Check if we can start (prevent conflicting operations)
+      if (landoStatusMonitor && !landoStatusMonitor.canTransition(activeLandoApp, LandoAppState.Starting)) {
+        const currentState = landoStatusMonitor.getState(activeLandoApp);
+        vscode.window.showWarningMessage(
+          `Cannot start: ${activeLandoApp.name} is currently ${getStateLabel(currentState).toLowerCase()}`
+        );
+        return;
+      }
+
+      // Mark as starting - this updates the UI immediately
+      landoStatusMonitor?.markStarting(activeLandoApp);
 
       const notification = vscode.window.showInformationMessage(
         `Starting ${activeLandoApp.name}... This may take a few minutes.`,
@@ -1297,9 +1329,11 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
 
       if (success) {
         vscode.window.showInformationMessage(`${activeLandoApp.name} started successfully`);
-        // Refresh the status
+        // Refresh the status - this will transition to Running state
         await landoStatusMonitor?.refresh();
       } else {
+        // Mark error state
+        landoStatusMonitor?.markError(activeLandoApp, 'Start command failed');
         vscode.window.showErrorMessage(`Failed to start ${activeLandoApp.name}`);
       }
     })
@@ -1312,6 +1346,18 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
         vscode.window.showErrorMessage('No active Lando app selected');
         return;
       }
+
+      // Check if we can stop (prevent conflicting operations)
+      if (landoStatusMonitor && !landoStatusMonitor.canTransition(activeLandoApp, LandoAppState.Stopping)) {
+        const currentState = landoStatusMonitor.getState(activeLandoApp);
+        vscode.window.showWarningMessage(
+          `Cannot stop: ${activeLandoApp.name} is currently ${getStateLabel(currentState).toLowerCase()}`
+        );
+        return;
+      }
+
+      // Mark as stopping - this updates the UI immediately
+      landoStatusMonitor?.markStopping(activeLandoApp);
 
       const notification = vscode.window.showInformationMessage(
         `Stopping ${activeLandoApp.name}...`,
@@ -1332,9 +1378,11 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
 
       if (success) {
         vscode.window.showInformationMessage(`${activeLandoApp.name} stopped successfully`);
-        // Refresh the status
+        // Refresh the status - this will transition to Stopped state
         await landoStatusMonitor?.refresh();
       } else {
+        // Mark error state
+        landoStatusMonitor?.markError(activeLandoApp, 'Stop command failed');
         vscode.window.showErrorMessage(`Failed to stop ${activeLandoApp.name}`);
       }
     })
@@ -1347,6 +1395,18 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
         vscode.window.showErrorMessage('No active Lando app selected');
         return;
       }
+
+      // Check if we can restart (treat as stopping - it's a compound operation)
+      if (landoStatusMonitor && !landoStatusMonitor.canTransition(activeLandoApp, LandoAppState.Stopping)) {
+        const currentState = landoStatusMonitor.getState(activeLandoApp);
+        vscode.window.showWarningMessage(
+          `Cannot restart: ${activeLandoApp.name} is currently ${getStateLabel(currentState).toLowerCase()}`
+        );
+        return;
+      }
+
+      // Mark as stopping for UI (restart = stop + start)
+      landoStatusMonitor?.markStopping(activeLandoApp);
 
       const notification = vscode.window.showInformationMessage(
         `Restarting ${activeLandoApp.name}... This may take a few minutes.`,
@@ -1367,9 +1427,11 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
 
       if (success) {
         vscode.window.showInformationMessage(`${activeLandoApp.name} restarted successfully`);
-        // Refresh the status
+        // Refresh the status - this will transition to Running state
         await landoStatusMonitor?.refresh();
       } else {
+        // Mark error state
+        landoStatusMonitor?.markError(activeLandoApp, 'Restart command failed');
         vscode.window.showErrorMessage(`Failed to restart ${activeLandoApp.name}`);
       }
     })
@@ -1380,6 +1442,15 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('extension.rebuildLandoApp', async () => {
       if (!activeLandoApp) {
         vscode.window.showErrorMessage('No active Lando app selected');
+        return;
+      }
+
+      // Check if we can rebuild (prevent conflicting operations)
+      if (landoStatusMonitor && !landoStatusMonitor.canTransition(activeLandoApp, LandoAppState.Rebuilding)) {
+        const currentState = landoStatusMonitor.getState(activeLandoApp);
+        vscode.window.showWarningMessage(
+          `Cannot rebuild: ${activeLandoApp.name} is currently ${getStateLabel(currentState).toLowerCase()}`
+        );
         return;
       }
 
@@ -1394,6 +1465,9 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
       if (confirm !== 'Rebuild') {
         return;
       }
+
+      // Mark as rebuilding - this updates the UI immediately
+      landoStatusMonitor?.markRebuilding(activeLandoApp);
 
       const notification = vscode.window.showInformationMessage(
         `Rebuilding ${activeLandoApp.name}... This may take several minutes.`,
@@ -1414,11 +1488,13 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
 
       if (success) {
         vscode.window.showInformationMessage(`${activeLandoApp.name} rebuilt successfully`);
-        // Refresh the status
+        // Refresh the status - this will transition to Running state
         await landoStatusMonitor?.refresh();
         // Check and reload PHP plugins after rebuild
         await checkAndReloadPhpPlugins();
       } else {
+        // Mark error state
+        landoStatusMonitor?.markError(activeLandoApp, 'Rebuild command failed');
         vscode.window.showErrorMessage(`Failed to rebuild ${activeLandoApp.name}`);
       }
     })
@@ -1429,6 +1505,15 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('extension.destroyLandoApp', async () => {
       if (!activeLandoApp) {
         vscode.window.showErrorMessage('No active Lando app selected');
+        return;
+      }
+
+      // Check if we can destroy (prevent conflicting operations)
+      if (landoStatusMonitor && !landoStatusMonitor.canTransition(activeLandoApp, LandoAppState.Destroying)) {
+        const currentState = landoStatusMonitor.getState(activeLandoApp);
+        vscode.window.showWarningMessage(
+          `Cannot destroy: ${activeLandoApp.name} is currently ${getStateLabel(currentState).toLowerCase()}`
+        );
         return;
       }
 
@@ -1451,6 +1536,7 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
       // Capture app name and root path early to prevent TOCTOU race condition
       const appName = activeLandoApp.name;
       const appRootPath = activeLandoApp.rootPath;
+      const appForState = activeLandoApp; // Capture reference for state machine
       const typedName = await vscode.window.showInputBox({
         prompt: `Type the app name "${appName}" to confirm destruction`,
         placeHolder: appName,
@@ -1465,6 +1551,9 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
       if (typedName !== appName) {
         return;
       }
+
+      // Mark as destroying - this updates the UI immediately
+      landoStatusMonitor?.markDestroying(appForState);
 
       const notification = vscode.window.showInformationMessage(
         `Destroying ${appName}...`,
@@ -1488,6 +1577,8 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
         // Refresh the status - app will now appear as stopped
         await landoStatusMonitor?.refresh();
       } else {
+        // Mark error state
+        landoStatusMonitor?.markError(appForState, 'Destroy command failed');
         vscode.window.showErrorMessage(`Failed to destroy ${appName}`);
       }
     })
@@ -1546,7 +1637,16 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
 
       // Check if the app is running
       const status = landoStatusMonitor?.getStatus(activeLandoApp);
-      if (!status?.running) {
+      const appState = status?.state ?? LandoAppState.Unknown;
+      
+      if (isStateBusy(appState)) {
+        vscode.window.showWarningMessage(
+          `${activeLandoApp.name} is ${getStateLabel(appState).toLowerCase()}, please wait...`
+        );
+        return;
+      }
+      
+      if (!isStateRunning(appState)) {
         const action = await vscode.window.showWarningMessage(
           `${activeLandoApp.name} is not running. Start it first?`,
           'Start',
@@ -1626,7 +1726,16 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
 
       // Check if the app is running
       const status = landoStatusMonitor?.getStatus(activeLandoApp);
-      if (!status?.running) {
+      const appState = status?.state ?? LandoAppState.Unknown;
+      
+      if (isStateBusy(appState)) {
+        vscode.window.showWarningMessage(
+          `${activeLandoApp.name} is ${getStateLabel(appState).toLowerCase()}, please wait...`
+        );
+        return;
+      }
+      
+      if (!isStateRunning(appState)) {
         const action = await vscode.window.showWarningMessage(
           `${activeLandoApp.name} is not running. Start it first?`,
           'Start',
@@ -1682,7 +1791,16 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
 
       // Check if the app is running
       const status = landoStatusMonitor?.getStatus(activeLandoApp);
-      if (!status?.running) {
+      const appState = status?.state ?? LandoAppState.Unknown;
+      
+      if (isStateBusy(appState)) {
+        vscode.window.showWarningMessage(
+          `${activeLandoApp.name} is ${getStateLabel(appState).toLowerCase()}, please wait...`
+        );
+        return;
+      }
+      
+      if (!isStateRunning(appState)) {
         const action = await vscode.window.showWarningMessage(
           `${activeLandoApp.name} is not running. Start it first?`,
           'Start',
@@ -1739,7 +1857,16 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
 
       // Check if the app is running
       const status = landoStatusMonitor?.getStatus(activeLandoApp);
-      if (!status?.running) {
+      const appState = status?.state ?? LandoAppState.Unknown;
+      
+      if (isStateBusy(appState)) {
+        vscode.window.showWarningMessage(
+          `${activeLandoApp.name} is ${getStateLabel(appState).toLowerCase()}, please wait...`
+        );
+        return;
+      }
+      
+      if (!isStateRunning(appState)) {
         const action = await vscode.window.showWarningMessage(
           `${activeLandoApp.name} is not running. Start it first?`,
           'Start',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1058,6 +1058,8 @@ function updateLandoAppsStatusBar(): void {
   } else {
     // No active app selected
     vscode.commands.executeCommand('setContext', 'lando:appRunning', false);
+    vscode.commands.executeCommand('setContext', 'lando:appBusy', false);
+    vscode.commands.executeCommand('setContext', 'lando:appState', undefined);
     landoAppsStatusBarItem.text = `$(server) ${appCount} Lando app${appCount > 1 ? 's' : ''}`;
     landoAppsStatusBarItem.tooltip = `${appCount} Lando app${appCount > 1 ? 's' : ''} detected - Click to select`;
     landoAppsStatusBarItem.backgroundColor = undefined;
@@ -1456,9 +1458,12 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
         return;
       }
 
+      // Capture app reference before await to prevent TOCTOU
+      const appToRebuild = activeLandoApp;
+
       // Warn user about destructive action
       const confirm = await vscode.window.showWarningMessage(
-        `Rebuild will destroy and recreate ${activeLandoApp.name}'s containers. ` +
+        `Rebuild will destroy and recreate ${appToRebuild.name}'s containers. ` +
         `Local data in containers will be lost. Continue?`,
         { modal: true },
         'Rebuild'
@@ -1468,36 +1473,45 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
         return;
       }
 
+      // Re-check guard after await - state may have changed
+      if (landoStatusMonitor && !landoStatusMonitor.canTransition(appToRebuild, LandoAppState.Rebuilding)) {
+        const currentState = landoStatusMonitor.getState(appToRebuild);
+        vscode.window.showWarningMessage(
+          `Cannot rebuild: ${appToRebuild.name} is currently ${getStateLabel(currentState).toLowerCase()}`
+        );
+        return;
+      }
+
       // Mark as rebuilding - this updates the UI immediately
-      landoStatusMonitor?.markRebuilding(activeLandoApp);
+      landoStatusMonitor?.markRebuilding(appToRebuild);
 
       const notification = vscode.window.showInformationMessage(
-        `Rebuilding ${activeLandoApp.name}... This may take several minutes.`,
+        `Rebuilding ${appToRebuild.name}... This may take several minutes.`,
         'Cancel'
       );
 
       const success = await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: `Rebuilding ${activeLandoApp.name}...`,
+          title: `Rebuilding ${appToRebuild.name}...`,
           cancellable: false
         },
         async () => {
-          const result = await rebuildLando(activeLandoApp!.rootPath, notification);
+          const result = await rebuildLando(appToRebuild.rootPath, notification);
           return result;
         }
       );
 
       if (success) {
-        vscode.window.showInformationMessage(`${activeLandoApp.name} rebuilt successfully`);
+        vscode.window.showInformationMessage(`${appToRebuild.name} rebuilt successfully`);
         // Refresh the status - this will transition to Running state
         await landoStatusMonitor?.refresh();
         // Check and reload PHP plugins after rebuild
         await checkAndReloadPhpPlugins();
       } else {
         // Mark error state
-        landoStatusMonitor?.markError(activeLandoApp, 'Rebuild command failed');
-        vscode.window.showErrorMessage(`Failed to rebuild ${activeLandoApp.name}`);
+        landoStatusMonitor?.markError(appToRebuild, 'Rebuild command failed');
+        vscode.window.showErrorMessage(`Failed to rebuild ${appToRebuild.name}`);
       }
     })
   );
@@ -1551,6 +1565,15 @@ function registerAppDetectionCommands(context: vscode.ExtensionContext): void {
       });
 
       if (typedName !== appName) {
+        return;
+      }
+
+      // Re-check guard after awaits - state may have changed
+      if (landoStatusMonitor && !landoStatusMonitor.canTransition(appForState, LandoAppState.Destroying)) {
+        const currentState = landoStatusMonitor.getState(appForState);
+        vscode.window.showWarningMessage(
+          `Cannot destroy: ${appName} is currently ${getStateLabel(currentState).toLowerCase()}`
+        );
         return;
       }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1005,6 +1005,8 @@ function updateLandoAppsStatusBar(): void {
   
   if (appCount === 0) {
     vscode.commands.executeCommand('setContext', 'lando:appRunning', false);
+    vscode.commands.executeCommand('setContext', 'lando:appBusy', false);
+    vscode.commands.executeCommand('setContext', 'lando:appState', undefined);
     landoAppsStatusBarItem.hide();
     return;
   }

--- a/src/landoAppState.test.ts
+++ b/src/landoAppState.test.ts
@@ -1,0 +1,411 @@
+import * as assert from "assert";
+import { suite, test, beforeEach } from "mocha";
+import {
+  LandoAppState,
+  LandoAppStateMachine,
+  StateChangeEvent,
+  isRunning,
+  isBusy,
+  isStopped,
+  isError,
+  getStateLabel,
+  BUSY_STATES,
+} from "./landoAppState";
+
+suite("LandoAppState Test Suite", () => {
+  suite("Helper Functions", () => {
+    test("isRunning returns true only for Running state", () => {
+      assert.strictEqual(isRunning(LandoAppState.Running), true);
+      assert.strictEqual(isRunning(LandoAppState.Stopped), false);
+      assert.strictEqual(isRunning(LandoAppState.Starting), false);
+      assert.strictEqual(isRunning(LandoAppState.Unknown), false);
+    });
+
+    test("isStopped returns true only for Stopped state", () => {
+      assert.strictEqual(isStopped(LandoAppState.Stopped), true);
+      assert.strictEqual(isStopped(LandoAppState.Running), false);
+      assert.strictEqual(isStopped(LandoAppState.Stopping), false);
+    });
+
+    test("isBusy returns true for transitional states", () => {
+      assert.strictEqual(isBusy(LandoAppState.Starting), true);
+      assert.strictEqual(isBusy(LandoAppState.Stopping), true);
+      assert.strictEqual(isBusy(LandoAppState.Rebuilding), true);
+      assert.strictEqual(isBusy(LandoAppState.Destroying), true);
+      assert.strictEqual(isBusy(LandoAppState.Running), false);
+      assert.strictEqual(isBusy(LandoAppState.Stopped), false);
+      assert.strictEqual(isBusy(LandoAppState.Error), false);
+    });
+
+    test("isError returns true only for Error state", () => {
+      assert.strictEqual(isError(LandoAppState.Error), true);
+      assert.strictEqual(isError(LandoAppState.Running), false);
+      assert.strictEqual(isError(LandoAppState.Stopped), false);
+    });
+
+    test("getStateLabel returns human-readable labels", () => {
+      assert.strictEqual(getStateLabel(LandoAppState.Unknown), "Unknown");
+      assert.strictEqual(getStateLabel(LandoAppState.Stopped), "Stopped");
+      assert.strictEqual(getStateLabel(LandoAppState.Starting), "Starting...");
+      assert.strictEqual(getStateLabel(LandoAppState.Running), "Running");
+      assert.strictEqual(getStateLabel(LandoAppState.Stopping), "Stopping...");
+      assert.strictEqual(
+        getStateLabel(LandoAppState.Rebuilding),
+        "Rebuilding..."
+      );
+      assert.strictEqual(
+        getStateLabel(LandoAppState.Destroying),
+        "Destroying..."
+      );
+      assert.strictEqual(getStateLabel(LandoAppState.Error), "Error");
+    });
+
+    test("BUSY_STATES contains all transitional states", () => {
+      assert.ok(BUSY_STATES.includes(LandoAppState.Starting));
+      assert.ok(BUSY_STATES.includes(LandoAppState.Stopping));
+      assert.ok(BUSY_STATES.includes(LandoAppState.Rebuilding));
+      assert.ok(BUSY_STATES.includes(LandoAppState.Destroying));
+      assert.strictEqual(BUSY_STATES.length, 4);
+    });
+  });
+
+  suite("LandoAppStateMachine", () => {
+    let stateMachine: LandoAppStateMachine;
+    const testAppId = "testapp";
+
+    beforeEach(() => {
+      stateMachine = new LandoAppStateMachine();
+    });
+
+    suite("Initial State", () => {
+      test("getState returns Unknown for untracked app", () => {
+        const info = stateMachine.getState(testAppId);
+        assert.strictEqual(info.state, LandoAppState.Unknown);
+      });
+
+      test("getState returns timestamp", () => {
+        const info = stateMachine.getState(testAppId);
+        assert.ok(info.timestamp instanceof Date);
+      });
+    });
+
+    suite("Valid Transitions", () => {
+      test("Unknown -> Stopped via poll", () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Stopped
+        );
+      });
+
+      test("Unknown -> Running via poll", () => {
+        stateMachine.updateFromPoll(testAppId, true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Running
+        );
+      });
+
+      test("Unknown -> Starting when user starts before poll", () => {
+        assert.strictEqual(stateMachine.markStarting(testAppId), true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Starting
+        );
+      });
+
+      test("Stopped -> Starting -> Running", () => {
+        stateMachine.updateFromPoll(testAppId, false); // Set to Stopped
+        assert.strictEqual(stateMachine.markStarting(testAppId), true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Starting
+        );
+
+        stateMachine.updateFromPoll(testAppId, true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Running
+        );
+      });
+
+      test("Running -> Stopping -> Stopped", () => {
+        stateMachine.updateFromPoll(testAppId, true); // Set to Running
+        assert.strictEqual(stateMachine.markStopping(testAppId), true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Stopping
+        );
+
+        stateMachine.updateFromPoll(testAppId, false);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Stopped
+        );
+      });
+
+      test("Running -> Rebuilding -> Running", () => {
+        stateMachine.updateFromPoll(testAppId, true);
+        assert.strictEqual(stateMachine.markRebuilding(testAppId), true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Rebuilding
+        );
+
+        stateMachine.updateFromPoll(testAppId, true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Running
+        );
+      });
+
+      test("Running -> Destroying -> Stopped", () => {
+        stateMachine.updateFromPoll(testAppId, true);
+        assert.strictEqual(stateMachine.markDestroying(testAppId), true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Destroying
+        );
+
+        stateMachine.updateFromPoll(testAppId, false);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Stopped
+        );
+      });
+    });
+
+    suite("Invalid Transitions", () => {
+      test("Cannot stop a stopped app", () => {
+        stateMachine.updateFromPoll(testAppId, false); // Stopped
+        assert.strictEqual(stateMachine.markStopping(testAppId), false);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Stopped
+        );
+      });
+
+      test("Cannot start a running app", () => {
+        stateMachine.updateFromPoll(testAppId, true); // Running
+        assert.strictEqual(stateMachine.markStarting(testAppId), false);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Running
+        );
+      });
+
+      test("Cannot start while stopping", () => {
+        stateMachine.updateFromPoll(testAppId, true);
+        stateMachine.markStopping(testAppId);
+        assert.strictEqual(stateMachine.markStarting(testAppId), false);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Stopping
+        );
+      });
+
+      test("Cannot stop while starting", () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        stateMachine.markStarting(testAppId);
+        assert.strictEqual(stateMachine.markStopping(testAppId), false);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Starting
+        );
+      });
+
+      test("Cannot rebuild a stopped app", () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        assert.strictEqual(stateMachine.markRebuilding(testAppId), false);
+      });
+
+      test("Cannot destroy a stopped app", () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        assert.strictEqual(stateMachine.markDestroying(testAppId), false);
+      });
+    });
+
+    suite("Error State", () => {
+      test("Can transition to Error from Starting", () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        stateMachine.markStarting(testAppId);
+        assert.strictEqual(
+          stateMachine.markError(testAppId, "Start failed"),
+          true
+        );
+
+        const info = stateMachine.getState(testAppId);
+        assert.strictEqual(info.state, LandoAppState.Error);
+        assert.strictEqual(info.errorMessage, "Start failed");
+        assert.strictEqual(info.previousState, LandoAppState.Starting);
+      });
+
+      test("Error state is cleared by poll", () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        stateMachine.markStarting(testAppId);
+        stateMachine.markError(testAppId, "Failed");
+
+        stateMachine.updateFromPoll(testAppId, false);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Stopped
+        );
+      });
+
+      test("Can retry from Error state", () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        stateMachine.markStarting(testAppId);
+        stateMachine.markError(testAppId, "Failed");
+
+        assert.strictEqual(stateMachine.markStarting(testAppId), true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Starting
+        );
+      });
+    });
+
+    suite("canTransition", () => {
+      test("Returns true for valid transitions", () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        assert.strictEqual(
+          stateMachine.canTransition(testAppId, LandoAppState.Starting),
+          true
+        );
+      });
+
+      test("Returns false for invalid transitions", () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        assert.strictEqual(
+          stateMachine.canTransition(testAppId, LandoAppState.Stopping),
+          false
+        );
+      });
+    });
+
+    suite("Events", () => {
+      test("Emits event on state change", () => {
+        const events: StateChangeEvent[] = [];
+        stateMachine.onDidChangeState((e) => events.push(e));
+
+        stateMachine.updateFromPoll(testAppId, true);
+
+        assert.strictEqual(events.length, 1);
+        assert.strictEqual(events[0].appId, testAppId);
+        assert.strictEqual(events[0].previousState, LandoAppState.Unknown);
+        assert.strictEqual(events[0].newState, LandoAppState.Running);
+      });
+
+      test("Does not emit event when state unchanged", () => {
+        const events: StateChangeEvent[] = [];
+        stateMachine.updateFromPoll(testAppId, true); // First change
+        stateMachine.onDidChangeState((e) => events.push(e));
+
+        stateMachine.updateFromPoll(testAppId, true); // Same state
+
+        assert.strictEqual(events.length, 0);
+      });
+
+      test("Includes error message in event", () => {
+        const events: StateChangeEvent[] = [];
+        stateMachine.updateFromPoll(testAppId, false);
+        stateMachine.markStarting(testAppId);
+        stateMachine.onDidChangeState((e) => events.push(e));
+
+        stateMachine.markError(testAppId, "Command failed");
+
+        assert.strictEqual(events.length, 1);
+        assert.strictEqual(events[0].errorMessage, "Command failed");
+      });
+    });
+
+    suite("App Management", () => {
+      test("removeApp removes app from tracking", () => {
+        stateMachine.updateFromPoll(testAppId, true);
+        stateMachine.removeApp(testAppId);
+
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Unknown
+        );
+      });
+
+      test("clear removes all tracked apps", () => {
+        stateMachine.updateFromPoll("app1", true);
+        stateMachine.updateFromPoll("app2", false);
+        stateMachine.clear();
+
+        assert.strictEqual(stateMachine.getTrackedApps().length, 0);
+      });
+
+      test("getTrackedApps returns all tracked app IDs", () => {
+        stateMachine.updateFromPoll("app1", true);
+        stateMachine.updateFromPoll("app2", false);
+
+        const tracked = stateMachine.getTrackedApps();
+        assert.strictEqual(tracked.length, 2);
+        assert.ok(tracked.includes("app1"));
+        assert.ok(tracked.includes("app2"));
+      });
+    });
+
+    suite("External State Changes", () => {
+      test("Detects external start (Stopped -> Running via poll)", () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        stateMachine.updateFromPoll(testAppId, true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Running
+        );
+      });
+
+      test("Detects external stop (Running -> Stopped via poll)", () => {
+        stateMachine.updateFromPoll(testAppId, true);
+        stateMachine.updateFromPoll(testAppId, false);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Stopped
+        );
+      });
+
+      test("Start command but still stopped on poll (external failure)", () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        stateMachine.markStarting(testAppId);
+        // Poll shows still stopped - start failed externally
+        stateMachine.updateFromPoll(testAppId, false);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Stopped
+        );
+      });
+
+      test("Stop command but still running on poll (external failure)", () => {
+        stateMachine.updateFromPoll(testAppId, true);
+        stateMachine.markStopping(testAppId);
+        // Poll shows still running - stop failed externally
+        stateMachine.updateFromPoll(testAppId, true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Running
+        );
+      });
+    });
+
+    suite("Timestamp Tracking", () => {
+      test("Updates timestamp on state change", async () => {
+        stateMachine.updateFromPoll(testAppId, false);
+        const firstTimestamp = stateMachine.getState(testAppId).timestamp;
+
+        await new Promise((resolve) => setTimeout(resolve, 10));
+
+        stateMachine.updateFromPoll(testAppId, true);
+        const secondTimestamp = stateMachine.getState(testAppId).timestamp;
+
+        assert.ok(
+          secondTimestamp.getTime() > firstTimestamp.getTime(),
+          "Timestamp should be updated"
+        );
+      });
+    });
+  });
+});

--- a/src/landoAppState.test.ts
+++ b/src/landoAppState.test.ts
@@ -214,14 +214,22 @@ suite("LandoAppState Test Suite", () => {
         );
       });
 
-      test("Cannot rebuild a stopped app", () => {
+      test("Can rebuild a stopped app", () => {
         stateMachine.updateFromPoll(testAppId, false);
-        assert.strictEqual(stateMachine.markRebuilding(testAppId), false);
+        assert.strictEqual(stateMachine.markRebuilding(testAppId), true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Rebuilding
+        );
       });
 
-      test("Cannot destroy a stopped app", () => {
+      test("Can destroy a stopped app", () => {
         stateMachine.updateFromPoll(testAppId, false);
-        assert.strictEqual(stateMachine.markDestroying(testAppId), false);
+        assert.strictEqual(stateMachine.markDestroying(testAppId), true);
+        assert.strictEqual(
+          stateMachine.getState(testAppId).state,
+          LandoAppState.Destroying
+        );
       });
     });
 

--- a/src/landoAppState.ts
+++ b/src/landoAppState.ts
@@ -234,6 +234,10 @@ export class LandoAppStateMachine implements vscode.Disposable {
    */
   canTransition(appId: string, toState: LandoAppState): boolean {
     const current = this.getState(appId);
+    // Same state is always a valid "transition" (no-op)
+    if (current.state === toState) {
+      return true;
+    }
     return VALID_TRANSITIONS[current.state]?.includes(toState) ?? false;
   }
 
@@ -353,10 +357,37 @@ export class LandoAppStateMachine implements vscode.Disposable {
       return;
     }
 
+    // Don't override busy states unless the poll result matches the expected outcome
+    // This prevents polling from interrupting in-progress operations (which take 30+ seconds)
+    if (isBusy(current.state)) {
+      const expectedOutcome = this.getExpectedOutcome(current.state);
+      if (targetState !== expectedOutcome) {
+        return;
+      }
+    }
+
     // Try to transition - this handles all the validation
     // For transitional states (Starting -> Running, Stopping -> Stopped, etc.)
     // the transition will succeed based on VALID_TRANSITIONS
     this.transition(appId, targetState);
+  }
+
+  /**
+   * Get the expected terminal state for a busy/transitional state
+   * @param state - The busy state
+   * @returns The expected terminal state
+   */
+  private getExpectedOutcome(state: LandoAppState): LandoAppState {
+    switch (state) {
+      case LandoAppState.Starting:
+      case LandoAppState.Rebuilding:
+        return LandoAppState.Running;
+      case LandoAppState.Stopping:
+      case LandoAppState.Destroying:
+        return LandoAppState.Stopped;
+      default:
+        return state;
+    }
   }
 
   /**

--- a/src/landoAppState.ts
+++ b/src/landoAppState.ts
@@ -1,0 +1,386 @@
+/**
+ * Lando App State Machine Module
+ *
+ * This module provides a finite state machine for managing Lando application states.
+ * It tracks transitional states (starting, stopping, etc.) and enforces valid
+ * state transitions to prevent conflicting operations.
+ *
+ * @module landoAppState
+ */
+
+import * as vscode from "vscode";
+
+/**
+ * Possible states for a Lando application
+ */
+export enum LandoAppState {
+  /** Initial state before first status check */
+  Unknown = "unknown",
+  /** All containers are stopped */
+  Stopped = "stopped",
+  /** lando start command is in progress */
+  Starting = "starting",
+  /** At least one container is running */
+  Running = "running",
+  /** lando stop command is in progress */
+  Stopping = "stopping",
+  /** lando rebuild command is in progress */
+  Rebuilding = "rebuilding",
+  /** lando destroy command is in progress */
+  Destroying = "destroying",
+  /** A command failed (transient state, cleared on next poll) */
+  Error = "error",
+}
+
+/**
+ * Information about an app's current state
+ */
+export interface LandoAppStateInfo {
+  /** Current state */
+  state: LandoAppState;
+  /** Error message when state is Error */
+  errorMessage?: string;
+  /** State before entering Error state (for recovery) */
+  previousState?: LandoAppState;
+  /** When this state was entered */
+  timestamp: Date;
+}
+
+/**
+ * Event emitted when app state changes
+ */
+export interface StateChangeEvent {
+  /** App identifier (cleanName) */
+  appId: string;
+  /** Previous state */
+  previousState: LandoAppState;
+  /** New state */
+  newState: LandoAppState;
+  /** Error message if transitioning to Error state */
+  errorMessage?: string;
+}
+
+/**
+ * Valid state transitions map.
+ * Key is the "from" state, value is array of valid "to" states.
+ */
+const VALID_TRANSITIONS: Record<LandoAppState, LandoAppState[]> = {
+  [LandoAppState.Unknown]: [
+    LandoAppState.Stopped,
+    LandoAppState.Running,
+    LandoAppState.Starting, // User may start before first poll
+    LandoAppState.Error,
+  ],
+  [LandoAppState.Stopped]: [
+    LandoAppState.Starting,
+    LandoAppState.Running, // Poll detects external start
+    LandoAppState.Error,
+  ],
+  [LandoAppState.Starting]: [
+    LandoAppState.Running,
+    LandoAppState.Stopped, // Poll shows still stopped (start failed externally)
+    LandoAppState.Error,
+  ],
+  [LandoAppState.Running]: [
+    LandoAppState.Stopping,
+    LandoAppState.Rebuilding,
+    LandoAppState.Destroying,
+    LandoAppState.Stopped, // Poll detects external stop
+    LandoAppState.Error,
+  ],
+  [LandoAppState.Stopping]: [
+    LandoAppState.Stopped,
+    LandoAppState.Running, // Poll shows still running (stop failed externally)
+    LandoAppState.Error,
+  ],
+  [LandoAppState.Rebuilding]: [
+    LandoAppState.Running,
+    LandoAppState.Stopped, // Rebuild can result in stopped state on failure
+    LandoAppState.Error,
+  ],
+  [LandoAppState.Destroying]: [
+    LandoAppState.Stopped,
+    LandoAppState.Running, // Poll shows still running (destroy failed externally)
+    LandoAppState.Error,
+  ],
+  [LandoAppState.Error]: [
+    // Error is transient - can go to any terminal state on next poll
+    LandoAppState.Stopped,
+    LandoAppState.Running,
+    // Can also retry operations from error state
+    LandoAppState.Starting,
+    LandoAppState.Stopping,
+    LandoAppState.Rebuilding,
+    LandoAppState.Destroying,
+  ],
+};
+
+/**
+ * States that indicate the app is busy with an operation
+ */
+export const BUSY_STATES: readonly LandoAppState[] = [
+  LandoAppState.Starting,
+  LandoAppState.Stopping,
+  LandoAppState.Rebuilding,
+  LandoAppState.Destroying,
+];
+
+/**
+ * Check if an app is in a running state
+ */
+export function isRunning(state: LandoAppState): boolean {
+  return state === LandoAppState.Running;
+}
+
+/**
+ * Check if an app is busy with an operation
+ */
+export function isBusy(state: LandoAppState): boolean {
+  return BUSY_STATES.includes(state);
+}
+
+/**
+ * Check if an app is in a stopped state
+ */
+export function isStopped(state: LandoAppState): boolean {
+  return state === LandoAppState.Stopped;
+}
+
+/**
+ * Check if an app is in an error state
+ */
+export function isError(state: LandoAppState): boolean {
+  return state === LandoAppState.Error;
+}
+
+/**
+ * Get a human-readable label for a state
+ */
+export function getStateLabel(state: LandoAppState): string {
+  switch (state) {
+    case LandoAppState.Unknown:
+      return "Unknown";
+    case LandoAppState.Stopped:
+      return "Stopped";
+    case LandoAppState.Starting:
+      return "Starting...";
+    case LandoAppState.Running:
+      return "Running";
+    case LandoAppState.Stopping:
+      return "Stopping...";
+    case LandoAppState.Rebuilding:
+      return "Rebuilding...";
+    case LandoAppState.Destroying:
+      return "Destroying...";
+    case LandoAppState.Error:
+      return "Error";
+  }
+}
+
+/**
+ * Manages state transitions for Lando applications.
+ *
+ * Features:
+ * - Enforces valid state transitions
+ * - Tracks per-app state with timestamps
+ * - Emits events on state changes
+ * - Provides helpers for marking transitional states
+ *
+ * @example
+ * ```typescript
+ * const stateMachine = new LandoAppStateMachine();
+ * stateMachine.onDidChangeState(event => {
+ *   console.log(`${event.appId}: ${event.previousState} -> ${event.newState}`);
+ * });
+ *
+ * stateMachine.markStarting('myapp');
+ * // ... after command completes ...
+ * stateMachine.updateFromPoll('myapp', true); // Now running
+ * ```
+ */
+export class LandoAppStateMachine implements vscode.Disposable {
+  private stateMap: Map<string, LandoAppStateInfo> = new Map();
+
+  private readonly _onDidChangeState =
+    new vscode.EventEmitter<StateChangeEvent>();
+
+  /**
+   * Event fired when any app's state changes
+   */
+  readonly onDidChangeState: vscode.Event<StateChangeEvent> =
+    this._onDidChangeState.event;
+
+  /**
+   * Get the current state info for an app
+   * @param appId - The app identifier (cleanName)
+   * @returns State info, or Unknown state if not tracked
+   */
+  getState(appId: string): LandoAppStateInfo {
+    return (
+      this.stateMap.get(appId) ?? {
+        state: LandoAppState.Unknown,
+        timestamp: new Date(),
+      }
+    );
+  }
+
+  /**
+   * Check if a transition from current state to target state is valid
+   * @param appId - The app identifier
+   * @param toState - The target state
+   * @returns true if the transition is valid
+   */
+  canTransition(appId: string, toState: LandoAppState): boolean {
+    const current = this.getState(appId);
+    return VALID_TRANSITIONS[current.state]?.includes(toState) ?? false;
+  }
+
+  /**
+   * Attempt to transition an app to a new state
+   * @param appId - The app identifier
+   * @param newState - The target state
+   * @param errorMessage - Optional error message (for Error state)
+   * @returns true if transition succeeded, false if invalid
+   */
+  transition(
+    appId: string,
+    newState: LandoAppState,
+    errorMessage?: string
+  ): boolean {
+    const current = this.getState(appId);
+
+    // Same state - no transition needed
+    if (current.state === newState) {
+      return true;
+    }
+
+    // Check if transition is valid
+    if (!this.canTransition(appId, newState)) {
+      return false;
+    }
+
+    const previousState = current.state;
+
+    // Build new state info
+    const newInfo: LandoAppStateInfo = {
+      state: newState,
+      timestamp: new Date(),
+    };
+
+    // Track error details
+    if (newState === LandoAppState.Error) {
+      newInfo.errorMessage = errorMessage;
+      newInfo.previousState = previousState;
+    }
+
+    this.stateMap.set(appId, newInfo);
+
+    // Emit change event
+    this._onDidChangeState.fire({
+      appId,
+      previousState,
+      newState,
+      errorMessage,
+    });
+
+    return true;
+  }
+
+  /**
+   * Mark an app as starting (used before running start command)
+   * @param appId - The app identifier
+   * @returns true if transition succeeded
+   */
+  markStarting(appId: string): boolean {
+    return this.transition(appId, LandoAppState.Starting);
+  }
+
+  /**
+   * Mark an app as stopping (used before running stop command)
+   * @param appId - The app identifier
+   * @returns true if transition succeeded
+   */
+  markStopping(appId: string): boolean {
+    return this.transition(appId, LandoAppState.Stopping);
+  }
+
+  /**
+   * Mark an app as rebuilding (used before running rebuild command)
+   * @param appId - The app identifier
+   * @returns true if transition succeeded
+   */
+  markRebuilding(appId: string): boolean {
+    return this.transition(appId, LandoAppState.Rebuilding);
+  }
+
+  /**
+   * Mark an app as being destroyed (used before running destroy command)
+   * @param appId - The app identifier
+   * @returns true if transition succeeded
+   */
+  markDestroying(appId: string): boolean {
+    return this.transition(appId, LandoAppState.Destroying);
+  }
+
+  /**
+   * Mark an app as having an error
+   * @param appId - The app identifier
+   * @param message - Error message
+   * @returns true if transition succeeded
+   */
+  markError(appId: string, message: string): boolean {
+    return this.transition(appId, LandoAppState.Error, message);
+  }
+
+  /**
+   * Update state based on poll results.
+   * This is the primary way state is updated after the initial transition.
+   * Handles clearing Error states and updating from transitional states.
+   *
+   * @param appId - The app identifier
+   * @param isRunning - Whether containers are running (from poll)
+   */
+  updateFromPoll(appId: string, isRunning: boolean): void {
+    const targetState = isRunning
+      ? LandoAppState.Running
+      : LandoAppState.Stopped;
+    const current = this.getState(appId);
+
+    // If already in the target terminal state, nothing to do
+    if (current.state === targetState) {
+      return;
+    }
+
+    // Try to transition - this handles all the validation
+    // For transitional states (Starting -> Running, Stopping -> Stopped, etc.)
+    // the transition will succeed based on VALID_TRANSITIONS
+    this.transition(appId, targetState);
+  }
+
+  /**
+   * Remove tracking for an app (e.g., when app is removed from workspace)
+   * @param appId - The app identifier
+   */
+  removeApp(appId: string): void {
+    this.stateMap.delete(appId);
+  }
+
+  /**
+   * Clear all tracked state
+   */
+  clear(): void {
+    this.stateMap.clear();
+  }
+
+  /**
+   * Get all tracked app IDs
+   */
+  getTrackedApps(): string[] {
+    return Array.from(this.stateMap.keys());
+  }
+
+  dispose(): void {
+    this._onDidChangeState.dispose();
+    this.stateMap.clear();
+  }
+}

--- a/src/landoAppState.ts
+++ b/src/landoAppState.ts
@@ -358,10 +358,11 @@ export class LandoAppStateMachine implements vscode.Disposable {
     }
 
     // Don't override busy states unless the poll result matches the expected outcome
+    // or the transition is explicitly valid (e.g., Stopping -> Running for restart)
     // This prevents polling from interrupting in-progress operations (which take 30+ seconds)
     if (isBusy(current.state)) {
       const expectedOutcome = this.getExpectedOutcome(current.state);
-      if (targetState !== expectedOutcome) {
+      if (targetState !== expectedOutcome && !this.canTransition(appId, targetState)) {
         return;
       }
     }

--- a/src/landoAppState.ts
+++ b/src/landoAppState.ts
@@ -74,6 +74,8 @@ const VALID_TRANSITIONS: Record<LandoAppState, LandoAppState[]> = {
   [LandoAppState.Stopped]: [
     LandoAppState.Starting,
     LandoAppState.Running, // Poll detects external start
+    LandoAppState.Rebuilding,
+    LandoAppState.Destroying,
     LandoAppState.Error,
   ],
   [LandoAppState.Starting]: [

--- a/src/landoStatusMonitor.test.ts
+++ b/src/landoStatusMonitor.test.ts
@@ -1,6 +1,11 @@
 import * as assert from "assert";
 import { suite, test, afterEach } from "mocha";
-import { LandoStatusMonitor, LandoContainer } from "./landoStatusMonitor";
+import { 
+  LandoStatusMonitor, 
+  LandoContainer, 
+  LandoAppState,
+  isStateRunning,
+} from "./landoStatusMonitor";
 import { LandoApp } from "./landoAppDetector";
 import * as vscode from "vscode";
 
@@ -121,7 +126,7 @@ suite("LandoStatusMonitor Test Suite", () => {
       const status = monitor.getStatus(app);
       
       assert.ok(status, "Status should be available");
-      assert.strictEqual(status!.running, true, "App should be running");
+      assert.strictEqual(status!.state, LandoAppState.Running, "App should be running");
       assert.strictEqual(status!.runningContainers, 2, "Should have 2 running containers");
       assert.strictEqual(status!.totalContainers, 2, "Should have 2 total containers");
     });
@@ -143,7 +148,7 @@ suite("LandoStatusMonitor Test Suite", () => {
       const status = monitor.getStatus(app);
       
       assert.ok(status, "Status should be available");
-      assert.strictEqual(status!.running, false, "App should not be running");
+      assert.strictEqual(status!.state, LandoAppState.Stopped, "App should not be running");
       assert.strictEqual(status!.runningContainers, 0, "Should have 0 running containers");
       assert.strictEqual(status!.totalContainers, 2, "Should have 2 total containers");
     });
@@ -165,7 +170,7 @@ suite("LandoStatusMonitor Test Suite", () => {
       const status = monitor.getStatus(app);
       
       assert.ok(status, "Status should be available");
-      assert.strictEqual(status!.running, true, "App should be running if any container is running");
+      assert.strictEqual(status!.state, LandoAppState.Running, "App should be running if any container is running");
       assert.strictEqual(status!.runningContainers, 1, "Should have 1 running container");
       assert.strictEqual(status!.totalContainers, 2, "Should have 2 total containers");
     });
@@ -183,7 +188,7 @@ suite("LandoStatusMonitor Test Suite", () => {
       const status = monitor.getStatus(app);
       
       assert.ok(status, "Status should be available");
-      assert.strictEqual(status!.running, false, "App should not be running with no containers");
+      assert.strictEqual(status!.state, LandoAppState.Stopped, "App should not be running with no containers");
       assert.strictEqual(status!.runningContainers, 0, "Should have 0 running containers");
       assert.strictEqual(status!.totalContainers, 0, "Should have 0 total containers");
     });
@@ -206,7 +211,7 @@ suite("LandoStatusMonitor Test Suite", () => {
       const status = monitor.getStatus(app);
       
       assert.ok(status, "Status should be available");
-      assert.strictEqual(status!.running, true, "App should be running");
+      assert.strictEqual(status!.state, LandoAppState.Running, "App should be running");
       assert.strictEqual(status!.runningContainers, 2, "Should have 2 running containers");
       assert.strictEqual(status!.totalContainers, 2, "Should have 2 total containers");
     });
@@ -229,7 +234,7 @@ suite("LandoStatusMonitor Test Suite", () => {
       const status = monitor.getStatus(app);
       
       assert.ok(status, "Status should be available");
-      assert.strictEqual(status!.running, true, "App should be running");
+      assert.strictEqual(status!.state, LandoAppState.Running, "App should be running");
       assert.strictEqual(status!.runningContainers, 1, "Should have 1 running container");
       assert.strictEqual(status!.totalContainers, 2, "Should have 2 total containers");
     });
@@ -258,8 +263,8 @@ suite("LandoStatusMonitor Test Suite", () => {
       
       assert.ok(status1, "Status for app1 should be available");
       assert.ok(status2, "Status for app2 should be available");
-      assert.strictEqual(status1!.running, true, "App1 should be running");
-      assert.strictEqual(status2!.running, false, "App2 should not be running");
+      assert.strictEqual(status1!.state, LandoAppState.Running, "App1 should be running");
+      assert.strictEqual(status2!.state, LandoAppState.Stopped, "App2 should not be running");
     });
 
     test("Should remove status when app is removed", async () => {
@@ -289,8 +294,8 @@ suite("LandoStatusMonitor Test Suite", () => {
     test("Should emit status changed event when app starts", async () => {
       const app = createMockApp("myapp");
       let eventFired = false;
-      let capturedWasRunning: boolean | undefined;
-      let capturedIsRunning: boolean | undefined;
+      let capturedPreviousState: LandoAppState | undefined;
+      let capturedCurrentState: LandoAppState | undefined;
 
       const { fetcher, setContainers } = createMutableFetcher();
       
@@ -300,8 +305,8 @@ suite("LandoStatusMonitor Test Suite", () => {
 
       monitor.onDidChangeStatus(event => {
         eventFired = true;
-        capturedWasRunning = event.wasRunning;
-        capturedIsRunning = event.status.running;
+        capturedPreviousState = event.previousState;
+        capturedCurrentState = event.status.state;
       });
 
       // First call: app is stopped
@@ -313,8 +318,8 @@ suite("LandoStatusMonitor Test Suite", () => {
 
       // Reset event tracking
       eventFired = false;
-      capturedWasRunning = undefined;
-      capturedIsRunning = undefined;
+      capturedPreviousState = undefined;
+      capturedCurrentState = undefined;
 
       // Second call: app is running
       setContainers([
@@ -323,15 +328,15 @@ suite("LandoStatusMonitor Test Suite", () => {
       await monitor.refresh();
 
       assert.strictEqual(eventFired, true, "Event should be fired");
-      assert.strictEqual(capturedWasRunning, false, "Was not running before");
-      assert.strictEqual(capturedIsRunning, true, "Is running now");
+      assert.strictEqual(capturedPreviousState, LandoAppState.Stopped, "Was stopped before");
+      assert.strictEqual(capturedCurrentState, LandoAppState.Running, "Is running now");
     });
 
     test("Should emit status changed event when app stops", async () => {
       const app = createMockApp("myapp");
       let eventFired = false;
-      let capturedWasRunning: boolean | undefined;
-      let capturedIsRunning: boolean | undefined;
+      let capturedPreviousState: LandoAppState | undefined;
+      let capturedCurrentState: LandoAppState | undefined;
 
       const { fetcher, setContainers } = createMutableFetcher();
       
@@ -341,8 +346,8 @@ suite("LandoStatusMonitor Test Suite", () => {
 
       monitor.onDidChangeStatus(event => {
         eventFired = true;
-        capturedWasRunning = event.wasRunning;
-        capturedIsRunning = event.status.running;
+        capturedPreviousState = event.previousState;
+        capturedCurrentState = event.status.state;
       });
 
       // First call: app is running
@@ -354,8 +359,8 @@ suite("LandoStatusMonitor Test Suite", () => {
 
       // Reset event tracking
       eventFired = false;
-      capturedWasRunning = undefined;
-      capturedIsRunning = undefined;
+      capturedPreviousState = undefined;
+      capturedCurrentState = undefined;
 
       // Second call: app is stopped
       setContainers([
@@ -364,8 +369,8 @@ suite("LandoStatusMonitor Test Suite", () => {
       await monitor.refresh();
 
       assert.strictEqual(eventFired, true, "Event should be fired");
-      assert.strictEqual(capturedWasRunning, true, "Was running before");
-      assert.strictEqual(capturedIsRunning, false, "Is not running now");
+      assert.strictEqual(capturedPreviousState, LandoAppState.Running, "Was running before");
+      assert.strictEqual(capturedCurrentState, LandoAppState.Stopped, "Is not running now");
     });
 
     test("Should not emit event when status unchanged", async () => {

--- a/src/landoStatusMonitor.ts
+++ b/src/landoStatusMonitor.ts
@@ -12,6 +12,24 @@ import * as vscode from 'vscode';
 import * as childProcess from 'child_process';
 import * as util from 'util';
 import { LandoApp } from './landoAppDetector';
+import {
+  LandoAppState,
+  LandoAppStateMachine,
+  StateChangeEvent,
+  isRunning as isStateRunning,
+  isBusy as isStateBusy,
+} from './landoAppState';
+
+// Re-export state machine types for convenience
+export {
+  LandoAppState,
+  StateChangeEvent,
+  isRunning as isStateRunning,
+  isBusy as isStateBusy,
+  isStopped as isStateStopped,
+  isError as isStateError,
+  getStateLabel,
+} from './landoAppState';
 
 const execAsync = util.promisify(childProcess.exec);
 
@@ -21,14 +39,16 @@ const execAsync = util.promisify(childProcess.exec);
 export interface LandoAppStatus {
   /** The Lando app this status belongs to */
   app: LandoApp;
-  /** Whether the app is currently running */
-  running: boolean;
+  /** Current state of the app */
+  state: LandoAppState;
   /** Number of running containers */
   runningContainers: number;
   /** Total number of containers */
   totalContainers: number;
   /** Last time the status was checked */
   lastChecked: Date;
+  /** Error message when state is Error */
+  errorMessage?: string;
 }
 
 /**
@@ -39,8 +59,8 @@ export interface LandoStatusChangedEvent {
   app: LandoApp;
   /** The new status */
   status: LandoAppStatus;
-  /** The previous running state */
-  wasRunning: boolean;
+  /** The previous state */
+  previousState: LandoAppState;
 }
 
 /**
@@ -85,12 +105,13 @@ export interface LandoStatusMonitorOptions {
  * - Emits events when app status changes (started/stopped)
  * - Configurable polling interval
  * - Efficient batch checking of all detected apps
+ * - State machine for tracking transitional states (starting, stopping, etc.)
  * 
  * @example
  * ```typescript
  * const monitor = new LandoStatusMonitor();
  * monitor.onDidChangeStatus(event => {
- *   console.log(`${event.app.name} is now ${event.status.running ? 'running' : 'stopped'}`);
+ *   console.log(`${event.app.name} is now ${event.status.state}`);
  * });
  * await monitor.activate(context, outputChannel);
  * monitor.setApps(detectedApps);
@@ -105,6 +126,7 @@ export class LandoStatusMonitor implements vscode.Disposable {
   private isPolling = false;
   private disposables: vscode.Disposable[] = [];
   private containerFetcher: ContainerFetcher;
+  private readonly stateMachine: LandoAppStateMachine;
 
   private readonly _onDidChangeStatus = new vscode.EventEmitter<LandoStatusChangedEvent>();
   
@@ -123,6 +145,7 @@ export class LandoStatusMonitor implements vscode.Disposable {
   constructor(options?: LandoStatusMonitorOptions) {
     this.config = this.loadConfig();
     this.containerFetcher = options?.containerFetcher ?? this.defaultContainerFetcher.bind(this);
+    this.stateMachine = new LandoAppStateMachine();
   }
 
   /**
@@ -186,15 +209,24 @@ export class LandoStatusMonitor implements vscode.Disposable {
    * @param apps - Array of Lando apps to monitor
    */
   public setApps(apps: LandoApp[]): void {
-    this.apps = apps;
+    const newAppCleanNames = new Set(apps.map(a => a.cleanName));
     
-    // Remove status entries for apps that no longer exist
+    // Remove status/state entries for apps that no longer exist
     const appPaths = new Set(apps.map(a => a.configPath));
     for (const [path] of this.statusMap) {
       if (!appPaths.has(path)) {
         this.statusMap.delete(path);
       }
     }
+    
+    // Clean up state machine for removed apps
+    for (const trackedAppId of this.stateMachine.getTrackedApps()) {
+      if (!newAppCleanNames.has(trackedAppId)) {
+        this.stateMachine.removeApp(trackedAppId);
+      }
+    }
+    
+    this.apps = apps;
 
     // Start or stop polling based on whether we have apps
     if (this.config.enabled) {
@@ -234,7 +266,141 @@ export class LandoStatusMonitor implements vscode.Disposable {
    */
   public isRunning(app: LandoApp): boolean {
     const status = this.statusMap.get(app.configPath);
-    return status?.running ?? false;
+    return status ? isStateRunning(status.state) : false;
+  }
+
+  /**
+   * Checks if a specific app is busy (in a transitional state)
+   * 
+   * @param app - The app to check
+   * @returns True if busy, false otherwise
+   */
+  public isBusy(app: LandoApp): boolean {
+    const status = this.statusMap.get(app.configPath);
+    return status ? isStateBusy(status.state) : false;
+  }
+
+  /**
+   * Gets the current state for an app
+   * 
+   * @param app - The app to get state for
+   * @returns The app's state
+   */
+  public getState(app: LandoApp): LandoAppState {
+    const status = this.statusMap.get(app.configPath);
+    return status?.state ?? LandoAppState.Unknown;
+  }
+
+  /**
+   * Checks if a state transition is valid for an app
+   * 
+   * @param app - The app to check
+   * @param toState - The target state
+   * @returns True if the transition is valid
+   */
+  public canTransition(app: LandoApp, toState: LandoAppState): boolean {
+    return this.stateMachine.canTransition(app.cleanName, toState);
+  }
+
+  /**
+   * Mark an app as starting (call before running start command)
+   * 
+   * @param app - The app being started
+   * @returns True if transition succeeded
+   */
+  public markStarting(app: LandoApp): boolean {
+    const success = this.stateMachine.markStarting(app.cleanName);
+    if (success) {
+      this.updateStatusFromStateMachine(app);
+    }
+    return success;
+  }
+
+  /**
+   * Mark an app as stopping (call before running stop command)
+   * 
+   * @param app - The app being stopped
+   * @returns True if transition succeeded
+   */
+  public markStopping(app: LandoApp): boolean {
+    const success = this.stateMachine.markStopping(app.cleanName);
+    if (success) {
+      this.updateStatusFromStateMachine(app);
+    }
+    return success;
+  }
+
+  /**
+   * Mark an app as rebuilding (call before running rebuild command)
+   * 
+   * @param app - The app being rebuilt
+   * @returns True if transition succeeded
+   */
+  public markRebuilding(app: LandoApp): boolean {
+    const success = this.stateMachine.markRebuilding(app.cleanName);
+    if (success) {
+      this.updateStatusFromStateMachine(app);
+    }
+    return success;
+  }
+
+  /**
+   * Mark an app as being destroyed (call before running destroy command)
+   * 
+   * @param app - The app being destroyed
+   * @returns True if transition succeeded
+   */
+  public markDestroying(app: LandoApp): boolean {
+    const success = this.stateMachine.markDestroying(app.cleanName);
+    if (success) {
+      this.updateStatusFromStateMachine(app);
+    }
+    return success;
+  }
+
+  /**
+   * Mark an app as having an error
+   * 
+   * @param app - The app that errored
+   * @param message - Error message
+   * @returns True if transition succeeded
+   */
+  public markError(app: LandoApp, message: string): boolean {
+    const success = this.stateMachine.markError(app.cleanName, message);
+    if (success) {
+      this.updateStatusFromStateMachine(app);
+    }
+    return success;
+  }
+
+  /**
+   * Updates the status map from the state machine's current state
+   */
+  private updateStatusFromStateMachine(app: LandoApp): void {
+    const stateInfo = this.stateMachine.getState(app.cleanName);
+    const existingStatus = this.statusMap.get(app.configPath);
+    const previousState = existingStatus?.state ?? LandoAppState.Unknown;
+    
+    const newStatus: LandoAppStatus = {
+      app,
+      state: stateInfo.state,
+      runningContainers: existingStatus?.runningContainers ?? 0,
+      totalContainers: existingStatus?.totalContainers ?? 0,
+      lastChecked: new Date(),
+      errorMessage: stateInfo.errorMessage,
+    };
+    
+    this.statusMap.set(app.configPath, newStatus);
+    
+    // Fire events
+    if (previousState !== stateInfo.state) {
+      this._onDidChangeStatus.fire({
+        app,
+        status: newStatus,
+        previousState,
+      });
+    }
+    this._onDidUpdateStatuses.fire(this.getAllStatuses());
   }
 
   /**
@@ -288,8 +454,7 @@ export class LandoStatusMonitor implements vscode.Disposable {
       const updatedStatuses: LandoAppStatus[] = [];
 
       for (const app of this.apps) {
-        const previousStatus = this.statusMap.get(app.configPath);
-        const wasRunning = previousStatus?.running ?? false;
+        const previousState = this.stateMachine.getState(app.cleanName).state;
 
         // Filter containers for this app
         // Normalize container app name the same way cleanName is created
@@ -303,24 +468,30 @@ export class LandoStatusMonitor implements vscode.Disposable {
         const totalContainers = appContainers.length;
         const isRunning = runningContainers > 0;
 
+        // Update state machine with poll results
+        // This handles transitional states (Starting -> Running, Stopping -> Stopped, etc.)
+        this.stateMachine.updateFromPoll(app.cleanName, isRunning);
+        const currentStateInfo = this.stateMachine.getState(app.cleanName);
+
         const newStatus: LandoAppStatus = {
           app,
-          running: isRunning,
+          state: currentStateInfo.state,
           runningContainers,
           totalContainers,
-          lastChecked: new Date()
+          lastChecked: new Date(),
+          errorMessage: currentStateInfo.errorMessage,
         };
 
         this.statusMap.set(app.configPath, newStatus);
         updatedStatuses.push(newStatus);
 
-        // Emit change event if status changed
-        if (wasRunning !== isRunning) {
-          this.log(`Status changed for ${app.name}: ${wasRunning ? 'running' : 'stopped'} -> ${isRunning ? 'running' : 'stopped'}`);
+        // Emit change event if state changed
+        if (previousState !== currentStateInfo.state) {
+          this.log(`State changed for ${app.name}: ${previousState} -> ${currentStateInfo.state}`);
           this._onDidChangeStatus.fire({
             app,
             status: newStatus,
-            wasRunning
+            previousState,
           });
         }
       }
@@ -369,6 +540,7 @@ export class LandoStatusMonitor implements vscode.Disposable {
     this.stopPolling();
     this._onDidChangeStatus.dispose();
     this._onDidUpdateStatuses.dispose();
+    this.stateMachine.dispose();
     this.disposables.forEach(d => d.dispose());
     this.disposables = [];
   }

--- a/src/landoTreeDataProvider.ts
+++ b/src/landoTreeDataProvider.ts
@@ -10,7 +10,14 @@
 import * as vscode from 'vscode';
 import * as childProcess from 'child_process';
 import { LandoApp, LandoAppDetector, LandoTooling } from './landoAppDetector';
-import { LandoStatusMonitor, LandoAppStatus } from './landoStatusMonitor';
+import { 
+  LandoStatusMonitor, 
+  LandoAppStatus, 
+  LandoAppState,
+  isStateRunning,
+  isStateBusy,
+  getStateLabel,
+} from './landoStatusMonitor';
 import { generateConnectionStrings } from './connectionString';
 import { getServiceIcon } from './serviceIcons';
 
@@ -358,29 +365,61 @@ export class LandoTreeItem extends vscode.TreeItem {
   }
 
   /**
-   * Updates the app status icon
+   * Updates the app status icon based on the app's state
    */
   public updateStatus(status: LandoAppStatus | undefined): void {
     if (this.type !== 'app') {
       return;
     }
 
-    const isRunning = status?.running ?? false;
-    this.iconPath = new vscode.ThemeIcon(
-      isRunning ? 'vm-running' : 'vm-outline',
-      isRunning 
-        ? new vscode.ThemeColor('testing.iconPassed')
-        : new vscode.ThemeColor('testing.iconSkipped')
-    );
+    const appState = status?.state ?? LandoAppState.Unknown;
+    this.iconPath = this.getStateIcon(appState);
 
     if (status) {
-      const statusText = isRunning ? 'Running' : 'Stopped';
+      const statusText = getStateLabel(appState);
       this.tooltip = new vscode.MarkdownString(
         `**${this.app?.name}**\n\n` +
         `Status: ${statusText} (${status.runningContainers}/${status.totalContainers} containers)\n\n` +
         `Recipe: ${this.app?.recipe || 'custom'}\n\n` +
         `Path: \`${this.app?.rootPath}\``
       );
+    }
+  }
+
+  /**
+   * Gets the appropriate icon for a given app state
+   */
+  private getStateIcon(state: LandoAppState): vscode.ThemeIcon {
+    switch (state) {
+      case LandoAppState.Running:
+        return new vscode.ThemeIcon(
+          'vm-running',
+          new vscode.ThemeColor('testing.iconPassed')
+        );
+      case LandoAppState.Stopped:
+        return new vscode.ThemeIcon(
+          'vm-outline',
+          new vscode.ThemeColor('testing.iconSkipped')
+        );
+      case LandoAppState.Starting:
+      case LandoAppState.Stopping:
+      case LandoAppState.Rebuilding:
+      case LandoAppState.Destroying:
+        return new vscode.ThemeIcon(
+          'sync~spin',
+          new vscode.ThemeColor('charts.yellow')
+        );
+      case LandoAppState.Error:
+        return new vscode.ThemeIcon(
+          'error',
+          new vscode.ThemeColor('testing.iconFailed')
+        );
+      case LandoAppState.Unknown:
+      default:
+        return new vscode.ThemeIcon(
+          'question',
+          new vscode.ThemeColor('testing.iconSkipped')
+        );
     }
   }
 }
@@ -797,7 +836,8 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
 
     // URLs group (only show if app is running)
     const status = this.statusMonitor?.getStatus(app);
-    if (status?.running) {
+    const appState = status?.state ?? LandoAppState.Unknown;
+    if (isStateRunning(appState)) {
       children.push(new LandoTreeItem(
         'URLs',
         'urlsGroup',


### PR DESCRIPTION
## Summary

This PR replaces the binary running/stopped model with a proper finite state machine for managing Lando app lifecycle states.

## Changes

- **New state machine** (`src/landoAppState.ts`) with 8 states:
  - `Unknown` - initial state before first status check
  - `Stopped` - all containers stopped
  - `Starting` - lando start in progress
  - `Running` - at least one container running
  - `Stopping` - lando stop in progress
  - `Rebuilding` - lando rebuild in progress
  - `Destroying` - lando destroy in progress
  - `Error` - command failed (transient, clears on next poll)

- **Command guards** prevent conflicting operations (e.g., can't start while stopping)

- **Spinner icons** in tree view during transitional states

- **Menu enablement** - commands are disabled when app is busy

## State Transitions

```
                    ┌──────────────┐
                    │   Unknown    │
                    └──────┬───────┘
                           │ (first poll)
              ┌────────────┴────────────┐
              ▼                         ▼
       ┌──────────┐              ┌──────────┐
       │ Stopped  │◄────────────►│ Running  │
       └────┬─────┘              └────┬─────┘
            │                         │
   start    │    ┌────────────────────┼────────────┐
   command  │    │                    │            │
            ▼    │ stop cmd     rebuild   destroy
       ┌──────────┐              ┌──────────┐  ┌────────────┐
       │ Starting │              │Rebuilding│  │ Destroying │
       └────┬─────┘              └────┬─────┘  └─────┬──────┘
            │                         │              │
            ▼                         ▼              ▼
       ┌──────────┐              ┌──────────┐  ┌──────────┐
       │ Running  │              │ Running  │  │ Stopped  │
       │ or Error │              │ or Error │  │ or Error │
       └──────────┘              └──────────┘  └──────────┘
```

## Files Changed

| File | Changes |
|------|---------|
| `src/landoAppState.ts` | NEW - State machine implementation |
| `src/landoAppState.test.ts` | NEW - 35 unit tests |
| `src/landoStatusMonitor.ts` | Integrate state machine, update interface |
| `src/landoStatusMonitor.test.ts` | Update tests for new API |
| `src/extension.ts` | Add command guards, state tracking |
| `src/landoTreeDataProvider.ts` | State-aware icons |
| `package.json` | Add `!lando:appBusy` to when clauses |

## Testing

- 520 tests passing
- 35 new unit tests for state machine
- All existing status monitor tests updated and passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core lifecycle/status plumbing (start/stop/rebuild/destroy and polling) to use a new state machine, which could affect command availability and UI state if transitions/polling behavior is wrong. No auth/security or external API surface changes beyond the extension’s own UI/commands.
> 
> **Overview**
> Introduces a finite state machine (`LandoAppState`) to model app lifecycle beyond *running/stopped* (e.g., `Starting`, `Stopping`, `Rebuilding`, `Destroying`, `Error`) and integrates it into `landoStatusMonitor` so polling updates state transitions instead of a single boolean.
> 
> Updates the extension UI and commands to be state-aware: adds `lando:appBusy`/`lando:appState` contexts, disables menu actions while busy, shows spinner/error icons and state labels in the status bar/tree, and adds command-side transition guards with immediate state marking plus error-state reporting on failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55817d60c3e3de0501f148e3996522bea48d66d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->