### PR TITLE
feat: Per-service tree view in Lando Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,20 @@ Seamlessly integrate [Lando](https://lando.dev) local development environments w
 #### 🗂️ **Lando Explorer Sidebar**
 - **Activity Bar Integration**: Lando icon in the VS Code Activity Bar for instant access
 - **Visual App Management**: See all your Lando apps at a glance with running/stopped status indicators
-- **Hierarchical Tree View**:
+- **Per-Service Tree View**: Each service is a self-contained node with its own URLs and connection details nested underneath -- no hunting through separate groups to find what belongs where
   - **Apps**: Root-level display of all detected Lando apps with status icons
-  - **Services**: Expandable list of services with type-specific icons and running state
+  - **Services**: Shown directly under each app with type-specific icons and running state
     - Visual icons identify service types at a glance: database, web server, cache, mail, search, and more
     - Color-coded status: green for running, gray for stopped
+    - Expand a service to see its URLs and connection info
     - Hover for detailed tooltip with service category and status
-  - **URLs**: Clickable URLs that open directly in your browser (shown when app is running)
-  - **Info**: Database connection details (host, port, user, password) with one-click copy
+  - **URLs**: Nested under their parent service -- click to open in browser, right-click to copy
+  - **Connection Info**: Database credentials and endpoints nested under their database service -- click any item to copy
+    - External connection info (host/port for connecting from your host machine)
+    - Internal connection info (for container-to-container connections)
+    - Database credentials (user, password, database name)
+    - **One-Click Connection Strings**: Ready-to-use database URLs (e.g., `mysql://user:pass@localhost:32769/db`) -- click to copy and paste directly into DBeaver, TablePlus, or your application config
   - **Tooling**: One-click access to tooling commands (drush, composer, npm, artisan, etc.)
-- **Connection Info at a Glance**: See database credentials and connection details without touching the CLI
-  - External connection info (host/port for connecting from your host machine)
-  - Internal connection info (for container-to-container connections)
-  - Database credentials (user, password, database name)
-  - **One-Click Connection Strings**: Ready-to-use database URLs (e.g., `mysql://user:pass@localhost:32769/db`) - click to copy and paste directly into DBeaver, TablePlus, or your application config
-  - Click any info item to copy its value to clipboard
 - **Service Actions**: Right-click on services to SSH in or view logs for that specific service
 - **Inline Actions**: Hover over items to see action buttons (Start, Stop, SSH, Copy URL, Copy Info)
 - **Context Menus**: Right-click for full action menus on apps, services, URLs, and info items

--- a/src/connectionString.ts
+++ b/src/connectionString.ts
@@ -198,7 +198,7 @@ export function generateConnectionStrings(input: ConnectionStringInput): Connect
     );
     
     results.push({
-      label: `${input.serviceName}: Connection URL (external)`,
+      label: `Connection URL (external)`,
       connectionString,
       type: 'external',
       protocol,
@@ -218,7 +218,7 @@ export function generateConnectionStrings(input: ConnectionStringInput): Connect
     );
     
     results.push({
-      label: `${input.serviceName}: Connection URL (internal)`,
+      label: `Connection URL (internal)`,
       connectionString,
       type: 'internal',
       protocol,

--- a/src/landoTreeDataProvider.test.ts
+++ b/src/landoTreeDataProvider.test.ts
@@ -15,14 +15,12 @@ import { LandoServiceUrl } from "./types";
  */
 type LandoTreeItemType = 
   | 'app'
-  | 'servicesGroup'
   | 'service'
-  | 'urlsGroup'
   | 'url'
   | 'toolingGroup'
   | 'tooling'
-  | 'infoGroup'
   | 'infoItem'
+  | 'connectionString'
   | 'loading'
   | 'noApps';
 
@@ -194,7 +192,7 @@ function parseInfoFromLandoInfo(infoArray: LandoServiceDetails[]): LandoInfoItem
     if (info.creds) {
       if (info.creds.database) {
         infoItems.push({
-          label: `${serviceName}: Database`,
+          label: 'Database',
           value: info.creds.database,
           service: serviceName,
           category: 'credentials'
@@ -202,7 +200,7 @@ function parseInfoFromLandoInfo(infoArray: LandoServiceDetails[]): LandoInfoItem
       }
       if (info.creds.user) {
         infoItems.push({
-          label: `${serviceName}: User`,
+          label: 'User',
           value: info.creds.user,
           service: serviceName,
           category: 'credentials'
@@ -210,7 +208,7 @@ function parseInfoFromLandoInfo(infoArray: LandoServiceDetails[]): LandoInfoItem
       }
       if (info.creds.password) {
         infoItems.push({
-          label: `${serviceName}: Password`,
+          label: 'Password',
           value: info.creds.password,
           service: serviceName,
           category: 'credentials'
@@ -222,7 +220,7 @@ function parseInfoFromLandoInfo(infoArray: LandoServiceDetails[]): LandoInfoItem
     if (info.external_connection) {
       if (info.external_connection.host) {
         infoItems.push({
-          label: `${serviceName}: Host (external)`,
+          label: 'Host (external)',
           value: info.external_connection.host,
           service: serviceName,
           category: 'connection'
@@ -230,7 +228,7 @@ function parseInfoFromLandoInfo(infoArray: LandoServiceDetails[]): LandoInfoItem
       }
       if (info.external_connection.port) {
         infoItems.push({
-          label: `${serviceName}: Port (external)`,
+          label: 'Port (external)',
           value: info.external_connection.port,
           service: serviceName,
           category: 'connection'
@@ -242,7 +240,7 @@ function parseInfoFromLandoInfo(infoArray: LandoServiceDetails[]): LandoInfoItem
     if (info.internal_connection) {
       if (info.internal_connection.host) {
         infoItems.push({
-          label: `${serviceName}: Host (internal)`,
+          label: 'Host (internal)',
           value: info.internal_connection.host,
           service: serviceName,
           category: 'connection'
@@ -250,7 +248,7 @@ function parseInfoFromLandoInfo(infoArray: LandoServiceDetails[]): LandoInfoItem
       }
       if (info.internal_connection.port) {
         infoItems.push({
-          label: `${serviceName}: Port (internal)`,
+          label: 'Port (internal)',
           value: info.internal_connection.port,
           service: serviceName,
           category: 'connection'
@@ -260,6 +258,32 @@ function parseInfoFromLandoInfo(infoArray: LandoServiceDetails[]): LandoInfoItem
   }
 
   return infoItems;
+}
+
+/**
+ * Filters info items for a specific service (mirrors getServiceChildren logic)
+ */
+function getServiceChildItems(
+  serviceName: string,
+  urls: LandoServiceUrl[],
+  infoItems: LandoInfoItem[]
+): { serviceUrls: LandoServiceUrl[], serviceInfo: LandoInfoItem[] } {
+  return {
+    serviceUrls: urls.filter(u => u.service === serviceName),
+    serviceInfo: infoItems.filter(i => i.service === serviceName),
+  };
+}
+
+/**
+ * Determines if a service should be expandable (has URLs or info children)
+ */
+function serviceHasChildren(
+  serviceName: string,
+  urls: LandoServiceUrl[],
+  infoItems: LandoInfoItem[]
+): boolean {
+  return urls.some(u => u.service === serviceName)
+    || infoItems.some(i => i.service === serviceName);
 }
 
 /**
@@ -289,22 +313,18 @@ function getIconForType(type: LandoTreeItemType): string {
   switch (type) {
     case 'app':
       return 'package';
-    case 'servicesGroup':
-      return 'server';
     case 'service':
       return 'circle-filled';
-    case 'urlsGroup':
-      return 'globe';
     case 'url':
       return 'link-external';
     case 'toolingGroup':
       return 'tools';
     case 'tooling':
       return 'terminal';
-    case 'infoGroup':
-      return 'database';
     case 'infoItem':
       return 'symbol-field';
+    case 'connectionString':
+      return 'link';
     case 'loading':
       return 'loading~spin';
     case 'noApps':
@@ -532,12 +552,12 @@ without commands section`;
   suite("Icon Selection", () => {
     test("Should return correct icons for each item type", () => {
       assert.strictEqual(getIconForType('app'), 'package');
-      assert.strictEqual(getIconForType('servicesGroup'), 'server');
       assert.strictEqual(getIconForType('service'), 'circle-filled');
-      assert.strictEqual(getIconForType('urlsGroup'), 'globe');
       assert.strictEqual(getIconForType('url'), 'link-external');
       assert.strictEqual(getIconForType('toolingGroup'), 'tools');
       assert.strictEqual(getIconForType('tooling'), 'terminal');
+      assert.strictEqual(getIconForType('infoItem'), 'symbol-field');
+      assert.strictEqual(getIconForType('connectionString'), 'link');
       assert.strictEqual(getIconForType('loading'), 'loading~spin');
       assert.strictEqual(getIconForType('noApps'), 'info');
     });
@@ -638,9 +658,9 @@ without commands section`;
       const infoItems = parseInfoFromLandoInfo(infoArray);
 
       assert.strictEqual(infoItems.length, 3);
-      assert.ok(infoItems.some(i => i.label === 'database: Database' && i.value === 'drupal10'));
-      assert.ok(infoItems.some(i => i.label === 'database: User' && i.value === 'drupal10'));
-      assert.ok(infoItems.some(i => i.label === 'database: Password' && i.value === 'drupal10'));
+      assert.ok(infoItems.some(i => i.label === 'Database' && i.value === 'drupal10'));
+      assert.ok(infoItems.some(i => i.label === 'User' && i.value === 'drupal10'));
+      assert.ok(infoItems.some(i => i.label === 'Password' && i.value === 'drupal10'));
     });
 
     test("Should parse external connection info from lando info output", () => {
@@ -658,8 +678,8 @@ without commands section`;
       const infoItems = parseInfoFromLandoInfo(infoArray);
 
       assert.strictEqual(infoItems.length, 2);
-      assert.ok(infoItems.some(i => i.label === 'database: Host (external)' && i.value === 'localhost'));
-      assert.ok(infoItems.some(i => i.label === 'database: Port (external)' && i.value === '32769'));
+      assert.ok(infoItems.some(i => i.label === 'Host (external)' && i.value === 'localhost'));
+      assert.ok(infoItems.some(i => i.label === 'Port (external)' && i.value === '32769'));
     });
 
     test("Should parse internal connection info from lando info output", () => {
@@ -677,8 +697,8 @@ without commands section`;
       const infoItems = parseInfoFromLandoInfo(infoArray);
 
       assert.strictEqual(infoItems.length, 2);
-      assert.ok(infoItems.some(i => i.label === 'database: Host (internal)' && i.value === 'database'));
-      assert.ok(infoItems.some(i => i.label === 'database: Port (internal)' && i.value === '3306'));
+      assert.ok(infoItems.some(i => i.label === 'Host (internal)' && i.value === 'database'));
+      assert.ok(infoItems.some(i => i.label === 'Port (internal)' && i.value === '3306'));
     });
 
     test("Should parse complete connection info for database service", () => {
@@ -772,7 +792,7 @@ without commands section`;
       const infoItems = parseInfoFromLandoInfo(infoArray);
 
       assert.strictEqual(infoItems.length, 1);
-      assert.strictEqual(infoItems[0].label, 'database: Database');
+      assert.strictEqual(infoItems[0].label, 'Database');
       assert.strictEqual(infoItems[0].value, 'mydb');
     });
 
@@ -784,29 +804,28 @@ without commands section`;
 
   suite("Info Item Icon Selection", () => {
     test("Should return server icon for host labels", () => {
-      assert.strictEqual(getIconForInfoItem('database: Host (external)'), 'server');
-      assert.strictEqual(getIconForInfoItem('database: Host (internal)'), 'server');
+      assert.strictEqual(getIconForInfoItem('Host (external)'), 'server');
+      assert.strictEqual(getIconForInfoItem('Host (internal)'), 'server');
       assert.strictEqual(getIconForInfoItem('Host'), 'server');
     });
 
     test("Should return plug icon for port labels", () => {
-      assert.strictEqual(getIconForInfoItem('database: Port (external)'), 'plug');
-      assert.strictEqual(getIconForInfoItem('database: Port (internal)'), 'plug');
+      assert.strictEqual(getIconForInfoItem('Port (external)'), 'plug');
+      assert.strictEqual(getIconForInfoItem('Port (internal)'), 'plug');
       assert.strictEqual(getIconForInfoItem('Port'), 'plug');
     });
 
     test("Should return person icon for user labels", () => {
-      assert.strictEqual(getIconForInfoItem('database: User'), 'person');
+      assert.strictEqual(getIconForInfoItem('User'), 'person');
       assert.strictEqual(getIconForInfoItem('Username'), 'person');
     });
 
     test("Should return key icon for password labels", () => {
-      assert.strictEqual(getIconForInfoItem('database: Password'), 'key');
       assert.strictEqual(getIconForInfoItem('Password'), 'key');
     });
 
     test("Should return database icon for database labels", () => {
-      assert.strictEqual(getIconForInfoItem('database: Database'), 'database');
+      assert.strictEqual(getIconForInfoItem('Database'), 'database');
       assert.strictEqual(getIconForInfoItem('Database Name'), 'database');
     });
 
@@ -816,13 +835,74 @@ without commands section`;
     });
   });
 
-  suite("Info Group Tree Item Type", () => {
-    test("Should return correct icon for infoGroup type", () => {
-      assert.strictEqual(getIconForType('infoGroup'), 'database');
+  suite("Service Children Filtering", () => {
+    test("Should filter URLs for a specific service", () => {
+      const urls: LandoServiceUrl[] = [
+        { service: 'appserver', url: 'https://app.lndo.site', primary: true },
+        { service: 'appserver', url: 'http://app.lndo.site', primary: false },
+        { service: 'mailhog', url: 'http://mail.lndo.site', primary: true },
+      ];
+      const infoItems: LandoInfoItem[] = [];
+
+      const { serviceUrls } = getServiceChildItems('appserver', urls, infoItems);
+      assert.strictEqual(serviceUrls.length, 2);
+      assert.ok(serviceUrls.every(u => u.service === 'appserver'));
     });
 
-    test("Should return correct icon for infoItem type", () => {
-      assert.strictEqual(getIconForType('infoItem'), 'symbol-field');
+    test("Should filter info items for a specific service", () => {
+      const urls: LandoServiceUrl[] = [];
+      const infoItems: LandoInfoItem[] = [
+        { label: 'Database', value: 'drupal', service: 'database', category: 'credentials' },
+        { label: 'User', value: 'root', service: 'database', category: 'credentials' },
+        { label: 'Host (internal)', value: 'cache', service: 'cache', category: 'connection' },
+      ];
+
+      const { serviceInfo } = getServiceChildItems('database', urls, infoItems);
+      assert.strictEqual(serviceInfo.length, 2);
+      assert.ok(serviceInfo.every(i => i.service === 'database'));
+    });
+
+    test("Should return empty arrays for service with no children", () => {
+      const urls: LandoServiceUrl[] = [
+        { service: 'appserver', url: 'https://app.lndo.site', primary: true },
+      ];
+      const infoItems: LandoInfoItem[] = [
+        { label: 'Database', value: 'drupal', service: 'database', category: 'credentials' },
+      ];
+
+      const { serviceUrls, serviceInfo } = getServiceChildItems('cache', urls, infoItems);
+      assert.strictEqual(serviceUrls.length, 0);
+      assert.strictEqual(serviceInfo.length, 0);
+    });
+
+    test("Should correctly determine if a service has children", () => {
+      const urls: LandoServiceUrl[] = [
+        { service: 'appserver', url: 'https://app.lndo.site', primary: true },
+      ];
+      const infoItems: LandoInfoItem[] = [
+        { label: 'Database', value: 'drupal', service: 'database', category: 'credentials' },
+      ];
+
+      // appserver has URLs
+      assert.strictEqual(serviceHasChildren('appserver', urls, infoItems), true);
+      // database has info items
+      assert.strictEqual(serviceHasChildren('database', urls, infoItems), true);
+      // cache has neither
+      assert.strictEqual(serviceHasChildren('cache', urls, infoItems), false);
+    });
+
+    test("Should combine URLs and info for a service with both", () => {
+      const urls: LandoServiceUrl[] = [
+        { service: 'appserver', url: 'https://app.lndo.site', primary: true },
+      ];
+      const infoItems: LandoInfoItem[] = [
+        { label: 'Host (external)', value: 'localhost', service: 'appserver', category: 'connection' },
+      ];
+
+      const { serviceUrls, serviceInfo } = getServiceChildItems('appserver', urls, infoItems);
+      assert.strictEqual(serviceUrls.length, 1);
+      assert.strictEqual(serviceInfo.length, 1);
+      assert.strictEqual(serviceHasChildren('appserver', urls, infoItems), true);
     });
   });
 });

--- a/src/landoTreeDataProvider.ts
+++ b/src/landoTreeDataProvider.ts
@@ -458,8 +458,13 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
     });
 
     // Listen for status changes
-    statusMonitor.onDidUpdateStatuses(() => {
+    statusMonitor.onDidChangeStatus(() => {
       this.clearCaches();
+      this._onDidChangeTreeData.fire();
+    });
+
+    // Listen for status updates (no cache clearing, just refresh UI)
+    statusMonitor.onDidUpdateStatuses(() => {
       this._onDidChangeTreeData.fire();
     });
 

--- a/src/landoTreeDataProvider.ts
+++ b/src/landoTreeDataProvider.ts
@@ -229,7 +229,6 @@ export class LandoTreeItem extends vscode.TreeItem {
     }
 
     this.iconPath = new vscode.ThemeIcon('link-external');
-    this.description = urlData.service;
     this.tooltip = `Open ${urlData.url} in browser`;
     this.command = {
       command: 'lando.openUrlDirect',

--- a/src/landoTreeDataProvider.ts
+++ b/src/landoTreeDataProvider.ts
@@ -459,6 +459,7 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
 
     // Listen for status changes
     statusMonitor.onDidUpdateStatuses(() => {
+      this.clearCaches();
       this._onDidChangeTreeData.fire();
     });
 

--- a/src/landoTreeDataProvider.ts
+++ b/src/landoTreeDataProvider.ts
@@ -14,8 +14,6 @@ import {
   LandoStatusMonitor, 
   LandoAppStatus, 
   LandoAppState,
-  isStateRunning,
-  isStateBusy,
   getStateLabel,
 } from './landoStatusMonitor';
 import { generateConnectionStrings } from './connectionString';
@@ -28,13 +26,10 @@ import { LANDO_CORE_COMMANDS } from './helpers/lando';
  */
 export type LandoTreeItemType = 
   | 'app'
-  | 'servicesGroup'
   | 'service'
-  | 'urlsGroup'
   | 'url'
   | 'toolingGroup'
   | 'tooling'
-  | 'infoGroup'
   | 'infoItem'
   | 'connectionString'
   | 'loading'
@@ -140,16 +135,8 @@ export class LandoTreeItem extends vscode.TreeItem {
       case 'app':
         this.setupAppItem();
         break;
-      case 'servicesGroup':
-        this.iconPath = new vscode.ThemeIcon('server');
-        this.description = 'Services';
-        break;
       case 'service':
         this.setupServiceItem();
-        break;
-      case 'urlsGroup':
-        this.iconPath = new vscode.ThemeIcon('globe');
-        this.description = 'URLs';
         break;
       case 'url':
         this.setupUrlItem();
@@ -160,10 +147,6 @@ export class LandoTreeItem extends vscode.TreeItem {
         break;
       case 'tooling':
         this.setupToolingItem();
-        break;
-      case 'infoGroup':
-        this.iconPath = new vscode.ThemeIcon('database');
-        this.description = 'Connection Info';
         break;
       case 'infoItem':
         this.setupInfoItem();
@@ -739,29 +722,20 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
       return this.getAppItems();
     }
 
-    // App level: show groups (Services, URLs, Tooling)
+    // App level: show services directly + tooling group
     if (element.type === 'app' && element.app) {
       return this.getAppChildren(element.app);
     }
 
-    // Services group: show services
-    if (element.type === 'servicesGroup' && element.app) {
-      return this.getServiceItems(element.app);
-    }
-
-    // URLs group: show URLs
-    if (element.type === 'urlsGroup' && element.app) {
-      return this.getUrlItems(element.app);
+    // Service level: show URLs, connection info, and connection strings for this service
+    if (element.type === 'service' && element.app) {
+      const service = element.data as LandoServiceInfo;
+      return this.getServiceChildren(element.app, service.name);
     }
 
     // Tooling group: show tooling commands
     if (element.type === 'toolingGroup' && element.app) {
       return this.getToolingItems(element.app);
-    }
-
-    // Info group: show connection details
-    if (element.type === 'infoGroup' && element.app) {
-      return this.getInfoItems(element.app);
     }
 
     return [];
@@ -811,39 +785,16 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
   }
 
   /**
-   * Gets children groups for an app
+   * Gets children for an app: individual services + tooling group.
+   * Services are shown directly (not in a group) so their URLs and
+   * connection info can be nested under each service.
    */
-  private getAppChildren(app: LandoApp): LandoTreeItem[] {
+  private async getAppChildren(app: LandoApp): Promise<LandoTreeItem[]> {
     const children: LandoTreeItem[] = [];
 
-    // Services group
-    children.push(new LandoTreeItem(
-      'Services',
-      'servicesGroup',
-      vscode.TreeItemCollapsibleState.Collapsed,
-      app
-    ));
-
-    // URLs group (only show if app is running)
-    const status = this.statusMonitor?.getStatus(app);
-    const appState = status?.state ?? LandoAppState.Unknown;
-    if (isStateRunning(appState)) {
-      children.push(new LandoTreeItem(
-        'URLs',
-        'urlsGroup',
-        vscode.TreeItemCollapsibleState.Collapsed,
-        app
-      ));
-      
-      // Info group - shows database connection details, ports, etc.
-      // Only shown when app is running since we need lando info data
-      children.push(new LandoTreeItem(
-        'Info',
-        'infoGroup',
-        vscode.TreeItemCollapsibleState.Collapsed,
-        app
-      ));
-    }
+    // Fetch service data
+    const serviceItems = await this.getServiceItems(app);
+    children.push(...serviceItems);
 
     // Tooling group
     children.push(new LandoTreeItem(
@@ -857,14 +808,56 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
   }
 
   /**
-   * Gets service items for an app
+   * Gets URL, connection info, and connection string items for a specific service.
+   * These are shown as children of the service node in the tree.
+   */
+  private async getServiceChildren(app: LandoApp, serviceName: string): Promise<LandoTreeItem[]> {
+    // Ensure info is fetched
+    if (!this.urlsCache.has(app.configPath) && !this.infoCache.has(app.configPath)) {
+      await this.fetchAppInfo(app);
+    }
+
+    const children: LandoTreeItem[] = [];
+
+    // URLs belonging to this service
+    const urls = this.urlsCache.get(app.configPath) ?? [];
+    const serviceUrls = urls.filter(u => u.service === serviceName);
+    for (const url of serviceUrls) {
+      children.push(new LandoTreeItem(
+        url.url,
+        'url',
+        vscode.TreeItemCollapsibleState.None,
+        app,
+        url
+      ));
+    }
+
+    // Connection info and connection strings belonging to this service
+    const infoItems = this.infoCache.get(app.configPath) ?? [];
+    const serviceInfo = infoItems.filter(i => i.service === serviceName);
+    for (const info of serviceInfo) {
+      children.push(new LandoTreeItem(
+        info.label,
+        info.category === 'connectionString' ? 'connectionString' : 'infoItem',
+        vscode.TreeItemCollapsibleState.None,
+        app,
+        info
+      ));
+    }
+
+    return children;
+  }
+
+  /**
+   * Gets service items for an app.
+   * Services are expandable when they have URLs or connection info to show.
    */
   private async getServiceItems(app: LandoApp): Promise<LandoTreeItem[]> {
     // Check cache first
     let services = this.servicesCache.get(app.configPath);
     
     if (!services) {
-      // Fetch services from lando info
+      // Fetch services from lando info (also populates URLs and info caches)
       await this.fetchAppInfo(app);
       services = this.servicesCache.get(app.configPath);
     }
@@ -881,43 +874,25 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
       ));
     }
 
-    return services.map(service => new LandoTreeItem(
-      service.name,
-      'service',
-      vscode.TreeItemCollapsibleState.None,
-      app,
-      service
-    ));
-  }
+    // Determine which services have children (URLs or info)
+    const urls = this.urlsCache.get(app.configPath) ?? [];
+    const infoItems = this.infoCache.get(app.configPath) ?? [];
 
-  /**
-   * Gets URL items for an app
-   */
-  private async getUrlItems(app: LandoApp): Promise<LandoTreeItem[]> {
-    // Check cache first
-    let urls = this.urlsCache.get(app.configPath);
-    
-    if (!urls) {
-      await this.fetchAppInfo(app);
-      urls = this.urlsCache.get(app.configPath);
-    }
+    return services.map(service => {
+      const hasChildren = urls.some(u => u.service === service.name) 
+        || infoItems.some(i => i.service === service.name);
+      const collapsibleState = hasChildren
+        ? vscode.TreeItemCollapsibleState.Collapsed
+        : vscode.TreeItemCollapsibleState.None;
 
-    if (!urls || urls.length === 0) {
-      return [new LandoTreeItem(
-        'No URLs available',
-        'loading',
-        vscode.TreeItemCollapsibleState.None,
-        app
-      )];
-    }
-
-    return urls.map(url => new LandoTreeItem(
-      url.url,
-      'url',
-      vscode.TreeItemCollapsibleState.None,
-      app,
-      url
-    ));
+      return new LandoTreeItem(
+        service.name,
+        'service',
+        collapsibleState,
+        app,
+        service
+      );
+    });
   }
 
   /**
@@ -960,37 +935,6 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
       vscode.TreeItemCollapsibleState.None,
       app,
       t
-    ));
-  }
-
-  /**
-   * Gets info items (connection details, credentials) for an app.
-   * These are extracted from lando info output for database and other services.
-   */
-  private async getInfoItems(app: LandoApp): Promise<LandoTreeItem[]> {
-    // Check cache first
-    let infoItems = this.infoCache.get(app.configPath);
-    
-    if (!infoItems) {
-      await this.fetchAppInfo(app);
-      infoItems = this.infoCache.get(app.configPath);
-    }
-
-    if (!infoItems || infoItems.length === 0) {
-      return [new LandoTreeItem(
-        'No connection info available',
-        'loading',
-        vscode.TreeItemCollapsibleState.None,
-        app
-      )];
-    }
-
-    return infoItems.map(info => new LandoTreeItem(
-      info.label,
-      info.category === 'connectionString' ? 'connectionString' : 'infoItem',
-      vscode.TreeItemCollapsibleState.None,
-      app,
-      info
     ));
   }
 
@@ -1070,11 +1014,10 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
             // Check if this service has credentials (typical for database services)
             if (info.creds) {
               const serviceName = info.service;
-              const serviceLabel = `${serviceName}`;
               
               if (info.creds.database) {
                 infoItems.push({
-                  label: `${serviceLabel}: Database`,
+                  label: 'Database',
                   value: info.creds.database,
                   service: serviceName,
                   category: 'credentials'
@@ -1082,7 +1025,7 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
               }
               if (info.creds.user) {
                 infoItems.push({
-                  label: `${serviceLabel}: User`,
+                  label: 'User',
                   value: info.creds.user,
                   service: serviceName,
                   category: 'credentials'
@@ -1090,7 +1033,7 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
               }
               if (info.creds.password) {
                 infoItems.push({
-                  label: `${serviceLabel}: Password`,
+                  label: 'Password',
                   value: info.creds.password,
                   service: serviceName,
                   category: 'credentials'
@@ -1101,11 +1044,10 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
             // Extract external connection info (for connecting from host machine)
             if (info.external_connection) {
               const serviceName = info.service;
-              const serviceLabel = `${serviceName}`;
               
               if (info.external_connection.host) {
                 infoItems.push({
-                  label: `${serviceLabel}: Host (external)`,
+                  label: 'Host (external)',
                   value: info.external_connection.host,
                   service: serviceName,
                   category: 'connection'
@@ -1113,7 +1055,7 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
               }
               if (info.external_connection.port) {
                 infoItems.push({
-                  label: `${serviceLabel}: Port (external)`,
+                  label: 'Port (external)',
                   value: String(info.external_connection.port),
                   service: serviceName,
                   category: 'connection'
@@ -1124,11 +1066,10 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
             // Extract internal connection info (container-to-container)
             if (info.internal_connection) {
               const serviceName = info.service;
-              const serviceLabel = `${serviceName}`;
               
               if (info.internal_connection.host) {
                 infoItems.push({
-                  label: `${serviceLabel}: Host (internal)`,
+                  label: 'Host (internal)',
                   value: info.internal_connection.host,
                   service: serviceName,
                   category: 'connection'
@@ -1136,7 +1077,7 @@ export class LandoTreeDataProvider implements vscode.TreeDataProvider<LandoTreeI
               }
               if (info.internal_connection.port) {
                 infoItems.push({
-                  label: `${serviceLabel}: Port (internal)`,
+                  label: 'Port (internal)',
                   value: String(info.internal_connection.port),
                   service: serviceName,
                   category: 'connection'


### PR DESCRIPTION
## Summary

Restructures the Lando Explorer sidebar so each service is an expandable node with its own URLs and connection info nested underneath, replacing the flat group layout (Services / URLs / Info).

**Before:**
```
My App
├── Services
│   ├── appserver (php)
│   └── database (mysql)
├── URLs
│   └── https://myapp.lndo.site
├── Info
│   ├── database: Host (external): localhost
│   └── database: Connection URL (external)
└── Tooling
```

**After:**
```
My App
├── appserver (php)
│   └── https://myapp.lndo.site
├── database (mysql)
│   ├── Host (external): localhost
│   └── Connection URL (external)
└── Tooling
```

- Services with URLs or connection info are expandable; services with neither stay as leaf nodes
- Info item labels no longer redundantly prefix the service name (the parent node provides that context)
- All existing context menus and inline actions continue to work unchanged
- New "Service Children Filtering" test suite (5 tests) covers URL/info grouping logic
- README updated to describe the per-service layout